### PR TITLE
feat: wire MCP protocol + fix PR review findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev:web": "cd apps/web && bun run dev",
     "test": "node --experimental-strip-types packages/schema/src/index.test.ts && bun run test:cli && bun run test:mcp && bun run test:registry",
     "test:cli": "node --experimental-strip-types packages/cli/src/registry-types.test.ts && node --experimental-strip-types packages/cli/src/commands/search.test.ts && node --experimental-strip-types packages/cli/src/commands/add.test.ts",
-    "test:mcp": "node --experimental-strip-types packages/mcp/src/handlers.test.ts",
+    "test:mcp": "node --experimental-strip-types packages/mcp/src/handlers.test.ts && node --experimental-strip-types packages/mcp/src/index.test.ts",
     "test:registry": "node --experimental-strip-types scripts/build-registry.test.ts",
     "typecheck": "tsc -p tsconfig.json",
     "validate:shaders": "node --experimental-strip-types scripts/validate-shaders.ts"

--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -1,0 +1,274 @@
+import assert from "node:assert/strict";
+
+// Import the Worker default export
+import worker from "./index.ts";
+
+function runTest(name: string, callback: () => void | Promise<void>) {
+  const result = callback();
+  if (result instanceof Promise) {
+    result.then(
+      () => console.log(`ok ${name}`),
+      (error) => {
+        console.error(`not ok ${name}`);
+        throw error;
+      },
+    );
+    return result;
+  }
+  console.log(`ok ${name}`);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASE_URL = "https://shaderbase-mcp.test.workers.dev";
+
+const env = {
+  // Use a dummy URL; the MCP protocol tests only exercise initialize/tools/list
+  // and don't actually hit the registry (except tools/call, which we test below)
+  REGISTRY_URL: "https://mock-registry.test",
+};
+
+function mcpRequest(body: Record<string, unknown>): Request {
+  return new Request(`${BASE_URL}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function fetchMcp(body: Record<string, unknown>): Promise<Response> {
+  return worker.fetch(mcpRequest(body), env);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+async function main() {
+  // --- Protocol basics ---
+
+  await runTest("POST /mcp initialize returns server info", async () => {
+    const res = await fetchMcp({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "test-client", version: "1.0.0" },
+      },
+    });
+    assert.equal(res.status, 200);
+    const data = await res.json() as Record<string, unknown>;
+    assert.equal(data.jsonrpc, "2.0");
+    assert.equal(data.id, 1);
+    const result = data.result as Record<string, unknown>;
+    assert.equal(result.protocolVersion, "2025-03-26");
+    const serverInfo = result.serverInfo as Record<string, string>;
+    assert.equal(serverInfo.name, "shaderbase");
+    assert.equal(serverInfo.version, "0.1.0");
+    const capabilities = result.capabilities as Record<string, unknown>;
+    assert.ok("tools" in capabilities);
+  });
+
+  await runTest("POST /mcp notifications/initialized returns 204", async () => {
+    const res = await fetchMcp({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+    assert.equal(res.status, 204);
+  });
+
+  await runTest("POST /mcp tools/list returns tool definitions", async () => {
+    const res = await fetchMcp({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+    });
+    assert.equal(res.status, 200);
+    const data = await res.json() as Record<string, unknown>;
+    assert.equal(data.id, 2);
+    const result = data.result as { tools: Array<{ name: string }> };
+    assert.equal(result.tools.length, 2);
+
+    const names = result.tools.map((t) => t.name).sort();
+    assert.deepEqual(names, ["get_shader", "search_shaders"]);
+
+    // Verify inputSchema is present on each tool
+    for (const tool of result.tools) {
+      const t = tool as unknown as { inputSchema: { type: string } };
+      assert.equal(t.inputSchema.type, "object");
+    }
+  });
+
+  await runTest("POST /mcp ping returns empty result", async () => {
+    const res = await fetchMcp({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "ping",
+    });
+    assert.equal(res.status, 200);
+    const data = await res.json() as Record<string, unknown>;
+    assert.equal(data.id, 3);
+    assert.deepEqual(data.result, {});
+  });
+
+  // --- Error handling ---
+
+  await runTest("POST /mcp unknown method returns -32601", async () => {
+    const res = await fetchMcp({
+      jsonrpc: "2.0",
+      id: 4,
+      method: "resources/list",
+    });
+    assert.equal(res.status, 200);
+    const data = await res.json() as Record<string, unknown>;
+    assert.equal(data.id, 4);
+    const err = data.error as { code: number; message: string };
+    assert.equal(err.code, -32601);
+    assert.ok(err.message.includes("resources/list"));
+  });
+
+  await runTest("POST /mcp invalid JSON returns parse error", async () => {
+    const res = await worker.fetch(
+      new Request(`${BASE_URL}/mcp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not valid json{{{",
+      }),
+      env,
+    );
+    assert.equal(res.status, 200);
+    const data = await res.json() as Record<string, unknown>;
+    const err = data.error as { code: number };
+    assert.equal(err.code, -32700);
+  });
+
+  await runTest("POST /mcp invalid jsonrpc version returns -32600", async () => {
+    const res = await fetchMcp({
+      jsonrpc: "1.0" as "2.0",
+      id: 5,
+      method: "initialize",
+    });
+    assert.equal(res.status, 200);
+    const data = await res.json() as Record<string, unknown>;
+    const err = data.error as { code: number };
+    assert.equal(err.code, -32600);
+  });
+
+  await runTest("POST /mcp tools/call with missing name returns error", async () => {
+    const res = await fetchMcp({
+      jsonrpc: "2.0",
+      id: 6,
+      method: "tools/call",
+      params: { arguments: {} },
+    });
+    assert.equal(res.status, 200);
+    const data = await res.json() as Record<string, unknown>;
+    const err = data.error as { code: number; message: string };
+    assert.equal(err.code, -32602);
+    assert.ok(err.message.includes("missing tool name"));
+  });
+
+  await runTest("POST /mcp tools/call with unknown tool returns error", async () => {
+    const res = await fetchMcp({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/call",
+      params: { name: "nonexistent_tool", arguments: {} },
+    });
+    assert.equal(res.status, 200);
+    const data = await res.json() as Record<string, unknown>;
+    const err = data.error as { code: number; message: string };
+    assert.equal(err.code, -32601);
+    assert.ok(err.message.includes("nonexistent_tool"));
+  });
+
+  // --- HTTP method handling ---
+
+  await runTest("GET /mcp returns 405", async () => {
+    const res = await worker.fetch(
+      new Request(`${BASE_URL}/mcp`, { method: "GET" }),
+      env,
+    );
+    assert.equal(res.status, 405);
+  });
+
+  await runTest("DELETE /mcp returns 405", async () => {
+    const res = await worker.fetch(
+      new Request(`${BASE_URL}/mcp`, { method: "DELETE" }),
+      env,
+    );
+    assert.equal(res.status, 405);
+  });
+
+  // --- CORS ---
+
+  await runTest("OPTIONS /mcp returns CORS headers", async () => {
+    const res = await worker.fetch(
+      new Request(`${BASE_URL}/mcp`, { method: "OPTIONS" }),
+      env,
+    );
+    assert.equal(res.status, 200);
+    assert.ok(res.headers.get("Access-Control-Allow-Origin"));
+    assert.ok(res.headers.get("Access-Control-Allow-Methods")?.includes("POST"));
+    assert.ok(res.headers.get("Access-Control-Allow-Headers")?.includes("Mcp-Session-Id"));
+  });
+
+  await runTest("POST /mcp responses include CORS headers", async () => {
+    const res = await fetchMcp({
+      jsonrpc: "2.0",
+      id: 10,
+      method: "ping",
+    });
+    assert.equal(res.headers.get("Access-Control-Allow-Origin"), "*");
+  });
+
+  // --- Unknown notification (no id) returns 204 ---
+
+  await runTest("POST /mcp unknown notification (no id) returns 204", async () => {
+    const res = await fetchMcp({
+      jsonrpc: "2.0",
+      method: "notifications/some_unknown",
+    });
+    assert.equal(res.status, 204);
+  });
+
+  // --- Legacy endpoints still work ---
+
+  await runTest("GET /health still works", async () => {
+    const res = await worker.fetch(
+      new Request(`${BASE_URL}/health`),
+      env,
+    );
+    assert.equal(res.status, 200);
+    const data = await res.json() as { status: string };
+    assert.equal(data.status, "ok");
+  });
+
+  await runTest("GET /tools still works", async () => {
+    const res = await worker.fetch(
+      new Request(`${BASE_URL}/tools`),
+      env,
+    );
+    assert.equal(res.status, 200);
+    const data = await res.json() as { tools: unknown[] };
+    assert.equal(data.tools.length, 2);
+  });
+
+  await runTest("GET / returns informational response with /mcp endpoint", async () => {
+    const res = await worker.fetch(
+      new Request(`${BASE_URL}/`),
+      env,
+    );
+    assert.equal(res.status, 200);
+    const data = await res.json() as { endpoints: Record<string, string> };
+    assert.ok("/mcp" in data.endpoints);
+  });
+
+  console.log("index tests passed");
+}
+
+main();

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -10,6 +10,21 @@ interface Env {
 
 const DEFAULT_REGISTRY_URL = "https://shaderbase-registry.pages.dev";
 
+// ---------------------------------------------------------------------------
+// JSON-RPC types
+// ---------------------------------------------------------------------------
+
+type JsonRpcRequest = {
+  jsonrpc: "2.0";
+  id?: string | number | null;
+  method: string;
+  params?: Record<string, unknown>;
+};
+
+// ---------------------------------------------------------------------------
+// Tool definitions — HTTP format (used by /tools endpoint)
+// ---------------------------------------------------------------------------
+
 const TOOLS = [
   {
     name: "search_shaders",
@@ -68,15 +83,144 @@ const TOOLS = [
   },
 ];
 
+// ---------------------------------------------------------------------------
+// Tool definitions — MCP protocol format (used by /mcp endpoint)
+// ---------------------------------------------------------------------------
+
+const TOOLS_MCP_FORMAT = [
+  {
+    name: "search_shaders",
+    description:
+      "Search the ShaderBase registry for Three.js shaders by query, category, pipeline, environment, or tags. Returns matching shaders with metadata including name, summary, tags, category, pipeline, and uniform signatures.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        query: {
+          type: "string",
+          description: "Free-text search against name, summary, and tags",
+        },
+        category: {
+          type: "string",
+          description: "Filter by category (e.g. 'color', 'geometry', 'post-processing')",
+        },
+        pipeline: {
+          type: "string",
+          description: "Filter by pipeline (e.g. 'surface', 'postprocessing', 'geometry')",
+        },
+        environment: {
+          type: "string",
+          description: "Filter by environment ('three' or 'r3f')",
+        },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+          description: "Filter by tags (all must match)",
+        },
+      },
+    },
+  },
+  {
+    name: "get_shader",
+    description:
+      "Get full shader details including GLSL source code and integration recipe, ready to copy into a Three.js or React Three Fiber project. Returns vertex shader, fragment shader, uniforms, and recipe code.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: {
+          type: "string",
+          description: "Shader name in kebab-case (e.g. 'gradient-radial')",
+        },
+        environment: {
+          type: "string",
+          description: "Only return recipe for this environment ('three' or 'r3f')",
+        },
+      },
+      required: ["name"] as const,
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// CORS headers
+// ---------------------------------------------------------------------------
+
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Accept, Authorization, Mcp-Session-Id",
+  "Access-Control-Expose-Headers": "Mcp-Session-Id",
+};
+
+// ---------------------------------------------------------------------------
+// Response helpers
+// ---------------------------------------------------------------------------
+
 function jsonResponse(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data, null, 2), {
     status,
     headers: {
       "Content-Type": "application/json",
-      "Access-Control-Allow-Origin": "*",
+      ...CORS_HEADERS,
     },
   });
 }
+
+function jsonRpcError(
+  id: string | number | null | undefined,
+  code: number,
+  message: string,
+): Response {
+  return jsonResponse({
+    jsonrpc: "2.0",
+    id: id ?? null,
+    error: { code, message },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// MCP tool call handler
+// ---------------------------------------------------------------------------
+
+async function handleMcpToolCall(
+  toolName: string,
+  toolArgs: Record<string, unknown>,
+  registryUrl: string,
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  if (toolName === "search_shaders") {
+    const results = await handleSearchShaders(
+      toolArgs as {
+        query?: string;
+        category?: string;
+        pipeline?: string;
+        environment?: string;
+        tags?: string[];
+      },
+      registryUrl,
+    );
+    return {
+      content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+    };
+  }
+
+  if (toolName === "get_shader") {
+    if (!toolArgs.name || typeof toolArgs.name !== "string") {
+      throw new Error("Missing required parameter: name");
+    }
+    const result = await handleGetShader(
+      toolArgs as { name: string; environment?: string },
+      registryUrl,
+    );
+    return {
+      content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+    };
+  }
+
+  throw new Error(`Unknown tool: ${toolName}`);
+}
+
+// ---------------------------------------------------------------------------
+// Worker fetch handler
+// ---------------------------------------------------------------------------
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -85,14 +229,120 @@ export default {
 
     // CORS preflight
     if (request.method === "OPTIONS") {
+      return new Response(null, { headers: CORS_HEADERS });
+    }
+
+    // -----------------------------------------------------------------------
+    // MCP Streamable HTTP transport — POST /mcp
+    // -----------------------------------------------------------------------
+    if (url.pathname === "/mcp" && request.method === "POST") {
+      let body: JsonRpcRequest;
+      try {
+        body = (await request.json()) as JsonRpcRequest;
+      } catch {
+        return jsonRpcError(null, -32700, "Parse error: invalid JSON");
+      }
+
+      if (body.jsonrpc !== "2.0") {
+        return jsonRpcError(body.id, -32600, "Invalid Request: jsonrpc must be \"2.0\"");
+      }
+
+      switch (body.method) {
+        // --- initialize ---
+        case "initialize":
+          return jsonResponse({
+            jsonrpc: "2.0",
+            id: body.id,
+            result: {
+              protocolVersion: "2025-03-26",
+              capabilities: { tools: {} },
+              serverInfo: {
+                name: "shaderbase",
+                version: "0.1.0",
+              },
+            },
+          });
+
+        // --- notifications/initialized ---
+        case "notifications/initialized":
+          return new Response(null, { status: 204, headers: CORS_HEADERS });
+
+        // --- tools/list ---
+        case "tools/list":
+          return jsonResponse({
+            jsonrpc: "2.0",
+            id: body.id,
+            result: { tools: TOOLS_MCP_FORMAT },
+          });
+
+        // --- tools/call ---
+        case "tools/call": {
+          const toolName = body.params?.name as string | undefined;
+          const toolArgs = (body.params?.arguments as Record<string, unknown>) ?? {};
+
+          if (!toolName) {
+            return jsonRpcError(body.id, -32602, "Invalid params: missing tool name");
+          }
+
+          try {
+            const result = await handleMcpToolCall(toolName, toolArgs, registryUrl);
+            return jsonResponse({
+              jsonrpc: "2.0",
+              id: body.id,
+              result,
+            });
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+
+            // If the tool is unknown, return method-not-found
+            if (message.startsWith("Unknown tool:")) {
+              return jsonRpcError(body.id, -32601, message);
+            }
+
+            // Tool execution errors: return as tool result with isError flag
+            return jsonResponse({
+              jsonrpc: "2.0",
+              id: body.id,
+              result: {
+                content: [{ type: "text", text: message }],
+                isError: true,
+              },
+            });
+          }
+        }
+
+        // --- ping ---
+        case "ping":
+          return jsonResponse({
+            jsonrpc: "2.0",
+            id: body.id,
+            result: {},
+          });
+
+        // --- unknown method ---
+        default:
+          // Notifications (methods without id) get 204
+          if (body.id === undefined || body.id === null) {
+            return new Response(null, { status: 204, headers: CORS_HEADERS });
+          }
+          return jsonRpcError(body.id, -32601, `Method not found: ${body.method}`);
+      }
+    }
+
+    // MCP endpoint — GET (SSE) and DELETE (session teardown) not supported
+    if (url.pathname === "/mcp" && (request.method === "GET" || request.method === "DELETE")) {
       return new Response(null, {
+        status: 405,
         headers: {
-          "Access-Control-Allow-Origin": "*",
-          "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-          "Access-Control-Allow-Headers": "Content-Type",
+          Allow: "POST, OPTIONS",
+          ...CORS_HEADERS,
         },
       });
     }
+
+    // -----------------------------------------------------------------------
+    // Legacy HTTP endpoints (unchanged)
+    // -----------------------------------------------------------------------
 
     // Health check
     if (url.pathname === "/health") {
@@ -150,6 +400,7 @@ export default {
         "/tools": "List available MCP tools and their input schemas",
         "/search_shaders": "Execute search_shaders tool (GET with query params or POST with JSON body)",
         "/get_shader": "Execute get_shader tool (GET with ?name=... or POST with JSON body)",
+        "/mcp": "MCP Streamable HTTP transport (POST with JSON-RPC 2.0)",
       },
     });
   },


### PR DESCRIPTION
## Summary

- **MCP protocol**: POST /mcp now speaks JSON-RPC 2.0 (initialize, tools/list, tools/call, ping) — agents can connect via `"url": "https://shaderbase-mcp.bats-678.workers.dev/mcp"`
- **PR review fixes**: auth on PR endpoint, tree SHA fix, manifest validation, typecheck in CI, @types/node
- **Provenance**: adapted/ported shaders populate sources from resolved metadata

## Test plan
- [x] 42 tests pass (25 original + 17 new MCP protocol tests)
- [x] Typecheck clean
- [x] MCP protocol verified live (initialize, tools/list, tools/call)
- [x] Registry serving at production URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)