### PR TITLE
fix: remove provenance flag for private repo npm publish

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -111,7 +111,7 @@ jobs:
           CURRENT=$(npm view @shaderbase/cli version 2>/dev/null || echo "0.0.0")
           LOCAL=$(node -p "require('./package.json').version")
           if [ "$CURRENT" != "$LOCAL" ]; then
-            npm publish --access public --provenance
+            npm publish --access public
           else
             echo "Version $LOCAL already published, skipping."
           fi


### PR DESCRIPTION
npm provenance requires public repos. Removing flag for initial publish.