### PR TITLE
fix: favicon and meta tags not rendering

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -44,10 +44,12 @@ function RootComponent() {
   return (
     <html>
       <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <HydrationScript />
+        <HeadContent />
       </head>
       <body class="min-h-screen bg-surface-primary font-sans text-text-primary antialiased">
-        <HeadContent />
         <Suspense>
           <Header />
           <Outlet />


### PR DESCRIPTION
## Summary
- Moved `<HeadContent />` from `<body>` into `<head>` in `__root.tsx`
- Favicon link and stylesheet tags were being ignored by browsers since they were in the body
- Added `<meta charset>` and `<meta viewport>` to the head

## Test plan
- [x] `bun run check` passes
- [x] Verified favicon visible in browser tab locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)