### PR TITLE
fix: validate shader reviews against registry, not filesystem

### DIFF
--- a/apps/web/src/routes/api/-reviews.ts
+++ b/apps/web/src/routes/api/-reviews.ts
@@ -16,14 +16,11 @@ type GetReviewsInput = {
 export const submitReview = createServerFn({ method: 'POST' })
   .inputValidator((input: SubmitReviewInput) => input)
   .handler(async ({ data }) => {
-    const { existsSync } = await import('node:fs')
-    const { join, resolve } = await import('node:path')
     const { addReview } = await import('../../lib/server/reviews-db')
+    const { listShadersFromSource } = await import('../../lib/server/shader-source')
 
-    const repoRoot = resolve(process.cwd(), '../..')
-    const shaderDir = join(repoRoot, 'shaders', data.shaderName)
-
-    if (!existsSync(shaderDir)) {
+    const shaders = await listShadersFromSource()
+    if (!shaders.some((s) => s.name === data.shaderName)) {
       throw new Error(`Shader "${data.shaderName}" not found`)
     }
 


### PR DESCRIPTION
## Summary
- Fix review submission failing in production with "Shader not found" error
- The validation was checking the local filesystem (`shaders/` dir) which doesn't exist on Railway
- Now validates against `listShadersFromSource()` which uses the registry CDN in production

## Test plan
- [x] `bun run check` passes
- [ ] After deploy: submit a review on shaderbase.com and verify it persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)