### PR TITLE
docs: rewrite README for public launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,10 @@
 # ShaderBase
 
-ShaderBase is an agent-first shader registry for Three.js ecosystems. Git-backed manifests and recipes are the canonical product. Search indexes, CLI tools, and MCP servers are derived artifacts.
+A shader registry for Three.js — browse, search, and add production-ready GLSL shaders to your project. Like [shadcn/ui](https://ui.shadcn.com), but for shaders: the CLI copies source files into your codebase. You own the code.
 
-## Architecture
+**[shaderbase.com](https://shaderbase.com)** · **[MCP server](https://mcp.shaderbase.com/mcp)**
 
-```
-shaders/              Canonical shader corpus (source of truth)
-packages/
-  schema/             Zod-based manifest validation
-  cli/                CLI: npx @shaderbase/cli search/add (shadcn-style)
-  mcp/                MCP server for AI agent integration (Cloudflare Worker)
-scripts/
-  build-registry.ts   Generates static registry JSON from corpus
-  validate-shaders.ts Validates all shader manifests
-apps/web/             SolidJS web app (browse, search, detail pages)
-```
-
-### How it works
-
-1. **Shaders live in git** — each shader has `shader.json`, GLSL source, and integration recipes
-2. **CI builds the registry** — static JSON index + per-shader bundles deployed to CDN
-3. **Agents use MCP** — `search_shaders` and `get_shader` tools via remote MCP server
-4. **Humans use the CLI** — `npx @shaderbase/cli add gradient-radial --env r3f`
-5. **Files are copied into your project** (shadcn-style) — you own the code
-
-## Quick Start
-
-```bash
-bun install
-bun run check        # test + typecheck + validate + build
-bun run dev:web      # dev server on :3000
-bun run build:registry  # generate dist/registry/
-```
-
-## Using ShaderBase
+## Usage
 
 ### CLI
 
@@ -42,11 +13,11 @@ bun run build:registry  # generate dist/registry/
 npx @shaderbase/cli search --query "gradient"
 npx @shaderbase/cli search --pipeline postprocessing --env r3f
 
-# Add a shader to your project
+# Add a shader to your project (copies files, you own them)
 npx @shaderbase/cli add gradient-radial --env r3f
 npx @shaderbase/cli add gradient-radial --env three --dir src/shaders
 
-# Submit a shader (creates a GitHub PR via AI analysis)
+# Submit a shader (AI parses your GLSL, creates a GitHub PR)
 npx @shaderbase/cli submit "void main() { gl_FragColor = vec4(1.0); }"
 npx @shaderbase/cli submit https://www.shadertoy.com/view/XsXXDn
 ```
@@ -54,6 +25,7 @@ npx @shaderbase/cli submit https://www.shadertoy.com/view/XsXXDn
 ### MCP (for AI agents)
 
 Add to your Claude config:
+
 ```json
 {
   "mcpServers": {
@@ -64,25 +36,55 @@ Add to your Claude config:
 }
 ```
 
-Tools: `search_shaders`, `get_shader`, and `submit_shader`
+Tools: `search_shaders`, `get_shader`, `submit_shader`
 
-## Repository Map
+## How it works
 
-| Path | Purpose |
-|------|---------|
-| `shaders/` | Canonical shader corpus |
-| `packages/schema/` | Zod manifest validation + types |
-| `packages/cli/` | CLI package (`shaderbase` on npm) |
-| `packages/mcp/` | MCP server (Cloudflare Worker) |
-| `scripts/` | Build and validation scripts |
-| `apps/web/` | Web app (browse, search, detail pages) |
-| `docs/` | Git contract, plans |
+1. **Shaders live in git** — each has a `shader.json` manifest, GLSL source, and integration recipes
+2. **CI builds the registry** — static JSON deployed to CDN
+3. **Agents use MCP** — remote server with search and retrieval tools
+4. **Humans use the CLI** — `npx @shaderbase/cli add <shader> --env r3f`
+5. **Files are copied into your project** — no runtime dependency, you own the code
+
+## Development
+
+### Prerequisites
+
+- [Bun](https://bun.sh) v1.3+
+- [Node.js](https://nodejs.org) v22+
+
+### Setup
+
+```bash
+bun install
+bun run dev:web          # dev server on :3000
+bun run check            # test + typecheck + validate + build
+bun run build:registry   # generate dist/registry/
+bun run test             # run all tests
+bun run validate:shaders # validate shader manifests
+```
+
+### Project structure
+
+```
+shaders/            Shader corpus (source of truth)
+packages/
+  schema/           Zod manifest validation + types
+  cli/              CLI: search, add, submit (@shaderbase/cli on npm)
+  mcp/              MCP server (Cloudflare Worker)
+apps/web/           SolidJS web app (browse, search, detail pages)
+scripts/            Registry build + shader validation
+```
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the provenance bar and submission checklist.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for provenance rules and the submission checklist.
 
 Submissions can be made via:
-- The CLI: `npx @shaderbase/cli submit <glsl-or-url>` (AI parses your GLSL, creates a PR)
-- The MCP `submit_shader` tool (for AI agents)
-- Direct pull request to the `shaders/` directory
+- **CLI**: `npx @shaderbase/cli submit <glsl-or-url>`
+- **MCP**: `submit_shader` tool
+- **Pull request**: directly to `shaders/`
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary
- Rewrites README to lead with value prop and usage instead of internal architecture
- Adds prerequisites (Bun v1.3+, Node v22+)
- Links to live site and MCP server
- Deduplicates structure sections

## Test plan
- [x] `bun run check` passes
- [x] No content changes, docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)