### PR TITLE
docs: improve README, fix MCP link, add shader submission PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/shader_submission.md
+++ b/.github/PULL_REQUEST_TEMPLATE/shader_submission.md
@@ -1,0 +1,51 @@
+## Add shader: `<name>`
+
+### Shader Details
+
+- **Name (slug):**
+- **Display name:**
+- **Category:** (surface / geometry / post-processing)
+- **Pipeline:** (vertex / fragment / postprocessing)
+- **Tags:**
+
+### Source Kind
+
+- [ ] Original — I wrote this shader
+- [ ] Adapted — modified from an existing shader
+- [ ] Ported — translated from another platform (e.g. ShaderToy, HLSL)
+
+### Provenance (adapted/ported only)
+
+- **Upstream URL:**
+- **Repository URL** (if source points to a file):
+- **Revision / snapshot marker:**
+- **Retrieval date** (YYYY-MM-DD):
+- **License:**
+- **Author(s):**
+- **Required downstream notice:**
+
+### Files
+
+- [ ] `shaders/<name>/shader.json` — valid manifest with complete metadata
+- [ ] GLSL source files — all files referenced in the manifest
+- [ ] Preview artwork
+- [ ] At least one integration recipe (e.g. `recipes/r3f.tsx`)
+
+### Attribution Verification
+
+Every adapted or ported shader must answer **all six** from the manifest alone:
+
+- [ ] Where did this code come from?
+- [ ] Which upstream artifact was used?
+- [ ] Which revision or snapshot was reviewed?
+- [ ] Under which license can we redistribute it?
+- [ ] Which names must remain credited?
+- [ ] What notice should downstream consumers preserve?
+
+### Validation
+
+- [ ] `bun run check` passes
+
+### Notes
+
+-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
+> Submitting a new shader? Use the [shader submission template](?template=shader_submission.md) instead.
+
 ## Summary
 
-- 
+-
 
 ## Provenance Checklist
 
@@ -13,4 +15,4 @@
 
 ## Notes
 
-- 
+-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,8 @@ ShaderBase accepts new shaders only when provenance is explicit and reproducible
 
 ## Submission Checklist
 
+When submitting via pull request, use the [shader submission PR template](.github/PULL_REQUEST_TEMPLATE/shader_submission.md) — it guides you through all required fields.
+
 For every shader entry under `shaders/<name>/`:
 
 - Add `shader.json` with valid schema metadata.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 A shader registry for Three.js — browse, search, and add production-ready GLSL shaders to your project. Like [shadcn/ui](https://ui.shadcn.com), but for shaders: the CLI copies source files into your codebase. You own the code.
 
-**[shaderbase.com](https://shaderbase.com)** · **[MCP server](https://mcp.shaderbase.com/mcp)**
+[![npm](https://img.shields.io/npm/v/@shaderbase/cli)](https://www.npmjs.com/package/@shaderbase/cli)
+[![CI](https://img.shields.io/github/actions/workflow/status/devallibus/shaderbase/validate.yml?branch=master)](https://github.com/devallibus/shaderbase/actions)
+[![License](https://img.shields.io/github/license/devallibus/shaderbase)](LICENSE)
 
-## Usage
+[Website](https://shaderbase.com) | [MCP Server](https://mcp.shaderbase.com) | [Contributing](CONTRIBUTING.md)
+
+---
+
+## Quick Start
 
 ### CLI
 
@@ -38,13 +44,23 @@ Add to your Claude config:
 
 Tools: `search_shaders`, `get_shader`, `submit_shader`
 
-## How it works
+## How It Works
 
 1. **Shaders live in git** — each has a `shader.json` manifest, GLSL source, and integration recipes
 2. **CI builds the registry** — static JSON deployed to CDN
 3. **Agents use MCP** — remote server with search and retrieval tools
 4. **Humans use the CLI** — `npx @shaderbase/cli add <shader> --env r3f`
 5. **Files are copied into your project** — no runtime dependency, you own the code
+
+## What's in the Registry
+
+The registry includes shaders across several categories:
+
+- **Surface** — gradients, noise patterns, color effects
+- **Geometry** — vertex displacement, morphing, particles
+- **Post-processing** — bloom, blur, distortion, color grading
+
+Browse the full collection at [shaderbase.com](https://shaderbase.com).
 
 ## Development
 
@@ -83,7 +99,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for provenance rules and the submission c
 Submissions can be made via:
 - **CLI**: `npx @shaderbase/cli submit <glsl-or-url>`
 - **MCP**: `submit_shader` tool
-- **Pull request**: directly to `shaders/`
+- **Pull request**: directly to `shaders/` — use the [shader submission template](.github/PULL_REQUEST_TEMPLATE/shader_submission.md)
 
 ## License
 


### PR DESCRIPTION
## Summary

- Add npm/CI/license badges and links row to README header
- Fix MCP header link to root URL (`https://mcp.shaderbase.com`) — the previous `/mcp` path returns 405 on GET
- Add "What's in the Registry" section with shader categories
- Create dedicated PR template for shader submissions (`.github/PULL_REQUEST_TEMPLATE/shader_submission.md`)
- Update general PR template with pointer to shader-specific template
- Add PR template reference in CONTRIBUTING.md
- Create repo labels: `shader-submission`, `schema`, `cli`, `mcp`, `web`, `documentation`

## Test plan

- [ ] Confirm badges render correctly on GitHub
- [ ] Verify `https://mcp.shaderbase.com` returns 200 (root link)
- [ ] Test shader PR template loads via `?template=shader_submission.md` on new PR page
- [ ] `bun run check` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)