### PR TITLE
chore: bump CLI version to 0.2.0 for npm publish

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shaderbase/cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "description": "Agent-first shader registry CLI for Three.js — search and add shaders to your project",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump `packages/cli/package.json` version from `0.1.0` to `0.2.0`
- CI's `publish-cli` job compares package.json version against npm — it was skipping because both were `0.1.0`

## Test plan

- [ ] CI `publish-cli` job runs and publishes `0.2.0` to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)