### PR TITLE
ci: switch npm publish to trusted publishing

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -128,9 +128,7 @@ jobs:
           CURRENT=$(npm view @shaderbase/cli version 2>/dev/null || echo "0.0.0")
           LOCAL=$(node -p "require('./package.json').version")
           if [ "$CURRENT" != "$LOCAL" ]; then
-            npm publish --access public
+            npm publish --access public --provenance
           else
             echo "Version $LOCAL already published, skipping."
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Replace `NPM_TOKEN` secret with npm trusted publishing (OIDC provenance)
- Add `--provenance` flag to `npm publish`
- Remove `NODE_AUTH_TOKEN` env var — auth handled via GitHub Actions OIDC

This will also publish `@shaderbase/cli@0.2.0` (version bump from PR #45).

## Test plan

- [ ] CI `publish-cli` job succeeds and publishes `0.2.0` to npm with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)