### PR TITLE
ci: restore NPM_TOKEN for npm publish auth

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -132,3 +132,5 @@ jobs:
           else
             echo "Version $LOCAL already published, skipping."
           fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Restore `NODE_AUTH_TOKEN` env var for npm publish authentication
- Keep `--provenance` flag for signed attestation (OIDC)
- npm needs token for auth + OIDC for provenance signing (separate concerns)

## Test plan

- [ ] CI `publish-cli` job publishes `@shaderbase/cli@0.2.0` to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)