### PR TITLE
ci: use npm trusted publishing (OIDC, no token)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -119,6 +119,9 @@ jobs:
       - name: Install Dependencies
         run: bun install --frozen-lockfile
 
+      - name: Upgrade npm (trusted publishing requires >= 11.5.1)
+        run: npm install -g npm@latest
+
       - name: Build CLI
         run: cd packages/cli && bun run build
 
@@ -132,5 +135,3 @@ jobs:
           else
             echo "Version $LOCAL already published, skipping."
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Remove `NODE_AUTH_TOKEN` — npm OIDC trusted publishing handles auth via `id-token: write`
- Add `npm install -g npm@latest` step (trusted publishing requires npm >= 11.5.1)
- Keep `--provenance` for signed attestation
- No more secrets needed for npm publish

Trusted publisher configured on npmjs.com for `devallibus/shaderbase`, workflow `validate.yml`, environment `npm`.

## Test plan

- [ ] CI `publish-cli` job publishes `@shaderbase/cli@0.2.0` to npm via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)