### PR TITLE
fix(playground): client-side session loading

### DIFF
--- a/apps/web/src/routes/api/playground/$.ts
+++ b/apps/web/src/routes/api/playground/$.ts
@@ -75,8 +75,9 @@ async function handlePlayground(request: Request): Promise<Response> {
   }
 
   // POST /api/playground/create
+  // No auth required — creating an empty session is harmless.
+  // The session UUID acts as the capability token.
   if (segments[0] === 'create' && request.method === 'POST') {
-    if (!isAuthorized(request)) return unauthorizedResponse()
     const body = (await request.json().catch(() => ({}))) as CreateSessionRequest
     const { id } = createSession(body)
     const response: CreateSessionResponse = {

--- a/apps/web/src/routes/playground.tsx
+++ b/apps/web/src/routes/playground.tsx
@@ -1,24 +1,7 @@
 import { createFileRoute, useNavigate } from '@tanstack/solid-router'
-import { createServerFn } from '@tanstack/solid-start'
-import { useServerFn } from '@tanstack/solid-start'
 import { createSignal, onMount, Show } from 'solid-js'
 import PlaygroundLayout from '../components/playground/PlaygroundLayout'
 import type { PlaygroundSession } from '../lib/playground-types'
-
-const getOrCreateSession = createServerFn({ method: 'GET' })
-  .inputValidator((data: { sessionId?: string }) => data)
-  .handler(async ({ data }) => {
-    const { createSession, getSession } = await import('../lib/server/playground-db')
-
-    if (data.sessionId) {
-      const session = getSession(data.sessionId)
-      if (session) return session
-    }
-
-    // No session ID or session not found — create a new one
-    const { session } = createSession()
-    return session
-  })
 
 export const Route = createFileRoute('/playground')({
   validateSearch: (search: Record<string, unknown>) => ({
@@ -29,28 +12,36 @@ export const Route = createFileRoute('/playground')({
 
 function PlaygroundPage() {
   const navigate = useNavigate()
-  const fetchSession = useServerFn(getOrCreateSession)
   const [session, setSession] = createSignal<PlaygroundSession | null>(null)
-  const [loading, setLoading] = createSignal(true)
-
-  // Read session ID from URL directly — useSearch reactive value isn't
-  // hydrated yet when onMount fires in TanStack Start + SolidJS.
-  const initialSessionId = typeof window !== 'undefined'
-    ? new URLSearchParams(window.location.search).get('session') || undefined
-    : undefined
 
   onMount(async () => {
-    try {
-      const result = await fetchSession({ data: { sessionId: initialSessionId } })
-      const s = result as PlaygroundSession
-      setSession(s)
+    const sessionId = new URLSearchParams(window.location.search).get('session') || undefined
 
-      // Update URL with session ID if it changed or was missing
-      if (initialSessionId !== s.id) {
-        navigate({ search: { session: s.id }, replace: true })
+    // If we have a session ID, try to load it; otherwise create a new one
+    let s: PlaygroundSession
+    if (sessionId) {
+      const res = await fetch(`/api/playground/${sessionId}/state`)
+      if (res.ok) {
+        s = await res.json()
+      } else {
+        // Session not found — create a new one
+        const createRes = await fetch('/api/playground/create', { method: 'POST' })
+        const { sessionId: newId } = await createRes.json()
+        const stateRes = await fetch(`/api/playground/${newId}/state`)
+        s = await stateRes.json()
       }
-    } finally {
-      setLoading(false)
+    } else {
+      const createRes = await fetch('/api/playground/create', { method: 'POST' })
+      const { sessionId: newId } = await createRes.json()
+      const stateRes = await fetch(`/api/playground/${newId}/state`)
+      s = await stateRes.json()
+    }
+
+    setSession(s)
+
+    // Update URL with session ID if it changed or was missing
+    if (sessionId !== s.id) {
+      navigate({ search: { session: s.id }, replace: true })
     }
   })
 


### PR DESCRIPTION
## Summary
- Replace `createServerFn`/`useServerFn` with direct API calls for session loading
- The playground doesn't need SSR — editor + canvas are purely client-side
- Eliminates hydration timing issues where `useSearch` reactive values aren't available when `onMount` fires
- Remove auth requirement from `POST /api/playground/create` (creating an empty session is harmless — the UUID is the capability token)

## What was wrong
1. `createResource` doesn't integrate with TanStack Router SSR streaming → blank page
2. `useServerFn` + `onMount` worked but `useSearch` reactive value isn't hydrated at mount time → session ID always `undefined` → MCP-created sessions ignored, new session created instead
3. Server function serialization (seroval) was sending `undefined` for the session ID

## How it works now
- `onMount` reads `?session=` from `window.location.search` directly
- Calls `/api/playground/:id/state` to load existing session, or `/api/playground/create` for new ones
- SSE push from MCP → browser already works (unchanged)

## Test plan
- [ ] Visit `/playground` → new session created, editor + canvas render
- [ ] MCP `create_playground` → get session URL → open in browser → same session loads (not a new one)
- [ ] MCP `update_shader` with browser open → canvas updates live via SSE
- [ ] MCP `get_errors` with broken GLSL → returns compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)