### PR TITLE
fix: close TSL post-merge follow-ups

### DIFF
--- a/apps/web/src/components/playground/PlaygroundCanvas.tsx
+++ b/apps/web/src/components/playground/PlaygroundCanvas.tsx
@@ -6,7 +6,7 @@ type PlaygroundCanvasProps = {
   vertexSource: string
   fragmentSource: string
   pipeline: string
-  language: string
+  language: 'glsl' | 'tsl'
   onError: (errors: string[]) => void
   onScreenshotReady: (base64: string) => void
 }
@@ -33,18 +33,18 @@ export default function PlaygroundCanvas(props: PlaygroundCanvasProps) {
   const [initError, setInitError] = createSignal('')
 
   onMount(async () => {
+    // TSL preview not yet implemented — show placeholder
+    if (props.language === 'tsl') {
+      setLoading(false)
+      return
+    }
+
     let THREE: THREE
     try {
       THREE = await import('three')
       threeModule = THREE
     } catch {
       setInitError('Failed to load 3D engine')
-      setLoading(false)
-      return
-    }
-
-    // TSL preview not yet implemented — show placeholder
-    if (props.language === 'tsl') {
       setLoading(false)
       return
     }

--- a/apps/web/src/components/playground/PlaygroundCanvas.tsx
+++ b/apps/web/src/components/playground/PlaygroundCanvas.tsx
@@ -6,6 +6,7 @@ type PlaygroundCanvasProps = {
   vertexSource: string
   fragmentSource: string
   pipeline: string
+  language: string
   onError: (errors: string[]) => void
   onScreenshotReady: (base64: string) => void
 }
@@ -38,6 +39,12 @@ export default function PlaygroundCanvas(props: PlaygroundCanvasProps) {
       threeModule = THREE
     } catch {
       setInitError('Failed to load 3D engine')
+      setLoading(false)
+      return
+    }
+
+    // TSL preview not yet implemented — show placeholder
+    if (props.language === 'tsl') {
       setLoading(false)
       return
     }
@@ -247,7 +254,7 @@ export default function PlaygroundCanvas(props: PlaygroundCanvasProps) {
     on(
       () => [props.vertexSource, props.fragmentSource] as const,
       ([vertex, fragment]) => {
-        if (!threeModule || !renderer) return
+        if (!threeModule || !renderer || props.language === 'tsl') return
         compileShader(threeModule, vertex, fragment)
       },
       { defer: true },
@@ -267,6 +274,16 @@ export default function PlaygroundCanvas(props: PlaygroundCanvasProps) {
       {initError() && (
         <div class="absolute inset-0 flex items-center justify-center p-4">
           <p class="text-sm text-danger">{initError()}</p>
+        </div>
+      )}
+      {!loading() && props.language === 'tsl' && (
+        <div class="absolute inset-0 flex items-center justify-center p-4">
+          <div class="text-center">
+            <p class="text-sm font-medium text-text-secondary">TSL Preview</p>
+            <p class="mt-1 text-xs text-text-muted">
+              WebGPU-based TSL preview coming soon.
+            </p>
+          </div>
         </div>
       )}
     </div>

--- a/apps/web/src/components/playground/PlaygroundLayout.tsx
+++ b/apps/web/src/components/playground/PlaygroundLayout.tsx
@@ -10,9 +10,15 @@ type PlaygroundLayoutProps = {
 
 export default function PlaygroundLayout(props: PlaygroundLayoutProps) {
   const [activeTab, setActiveTab] = createSignal<'fragment' | 'vertex'>('fragment')
-  const [vertexSource, setVertexSource] = createSignal(props.session.vertexSource)
-  const [fragmentSource, setFragmentSource] = createSignal(props.session.fragmentSource)
-  const [tslSource, setTslSource] = createSignal(props.session.tslSource ?? '')
+  const [vertexSource, setVertexSource] = createSignal(
+    props.session.language === 'glsl' ? props.session.vertexSource : '',
+  )
+  const [fragmentSource, setFragmentSource] = createSignal(
+    props.session.language === 'glsl' ? props.session.fragmentSource : '',
+  )
+  const [tslSource, setTslSource] = createSignal(
+    props.session.language === 'tsl' ? props.session.tslSource : '',
+  )
   const [errors, setErrors] = createSignal<string[]>(props.session.compilationErrors)
 
   let debounceTimer: ReturnType<typeof setTimeout> | null = null
@@ -27,14 +33,15 @@ export default function PlaygroundLayout(props: PlaygroundLayoutProps) {
       try {
         const data = JSON.parse(e.data) as {
           language: string
-          vertexSource: string
-          fragmentSource: string
-          tslSource: string | null
+          vertexSource?: string
+          fragmentSource?: string
+          tslSource?: string
         }
-        setVertexSource(data.vertexSource)
-        setFragmentSource(data.fragmentSource)
-        if (data.tslSource !== null && data.tslSource !== undefined) {
-          setTslSource(data.tslSource)
+        if (data.language === 'glsl') {
+          if (data.vertexSource !== undefined) setVertexSource(data.vertexSource)
+          if (data.fragmentSource !== undefined) setFragmentSource(data.fragmentSource)
+        } else if (data.language === 'tsl') {
+          if (data.tslSource !== undefined) setTslSource(data.tslSource)
         }
       } catch {
         // Ignore malformed events

--- a/apps/web/src/components/playground/PlaygroundLayout.tsx
+++ b/apps/web/src/components/playground/PlaygroundLayout.tsx
@@ -12,6 +12,7 @@ export default function PlaygroundLayout(props: PlaygroundLayoutProps) {
   const [activeTab, setActiveTab] = createSignal<'fragment' | 'vertex'>('fragment')
   const [vertexSource, setVertexSource] = createSignal(props.session.vertexSource)
   const [fragmentSource, setFragmentSource] = createSignal(props.session.fragmentSource)
+  const [tslSource, setTslSource] = createSignal(props.session.tslSource ?? '')
   const [errors, setErrors] = createSignal<string[]>(props.session.compilationErrors)
 
   let debounceTimer: ReturnType<typeof setTimeout> | null = null
@@ -24,9 +25,17 @@ export default function PlaygroundLayout(props: PlaygroundLayoutProps) {
 
     eventSource.addEventListener('shader_update', (e) => {
       try {
-        const data = JSON.parse(e.data) as { vertexSource: string; fragmentSource: string }
+        const data = JSON.parse(e.data) as {
+          language: string
+          vertexSource: string
+          fragmentSource: string
+          tslSource: string | null
+        }
         setVertexSource(data.vertexSource)
         setFragmentSource(data.fragmentSource)
+        if (data.tslSource !== null && data.tslSource !== undefined) {
+          setTslSource(data.tslSource)
+        }
       } catch {
         // Ignore malformed events
       }
@@ -47,13 +56,14 @@ export default function PlaygroundLayout(props: PlaygroundLayoutProps) {
   })
 
   function handleEditorChange(value: string) {
-    if (activeTab() === 'fragment') {
+    if (props.session.language === 'tsl') {
+      setTslSource(value)
+    } else if (activeTab() === 'fragment') {
       setFragmentSource(value)
     } else {
       setVertexSource(value)
     }
 
-    // Debounce manual edits before syncing to server
     if (debounceTimer) clearTimeout(debounceTimer)
     debounceTimer = setTimeout(() => {
       syncToServer()
@@ -62,13 +72,14 @@ export default function PlaygroundLayout(props: PlaygroundLayoutProps) {
 
   async function syncToServer() {
     try {
+      const body = props.session.language === 'tsl'
+        ? { tslSource: tslSource() }
+        : { vertexSource: vertexSource(), fragmentSource: fragmentSource() }
+
       await fetch(`/api/playground/${props.session.id}/update`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          vertexSource: vertexSource(),
-          fragmentSource: fragmentSource(),
-        }),
+        body: JSON.stringify(body),
       })
     } catch {
       // Network error — will retry on next edit
@@ -93,7 +104,10 @@ export default function PlaygroundLayout(props: PlaygroundLayoutProps) {
     }).catch(() => {})
   }
 
-  const currentEditorValue = () => (activeTab() === 'fragment' ? fragmentSource() : vertexSource())
+  const currentEditorValue = () => {
+    if (props.session.language === 'tsl') return tslSource()
+    return activeTab() === 'fragment' ? fragmentSource() : vertexSource()
+  }
 
   return (
     <div class="flex h-[calc(100vh-56px)] flex-col lg:flex-row">
@@ -101,26 +115,41 @@ export default function PlaygroundLayout(props: PlaygroundLayoutProps) {
       <div class="flex min-h-0 flex-1 flex-col border-r border-surface-card-border">
         {/* Tab bar */}
         <div class="flex border-b border-surface-card-border bg-surface-primary">
-          <button
-            class={`px-4 py-2 text-xs font-medium transition ${
-              activeTab() === 'fragment'
-                ? 'border-b-2 border-accent text-text-primary'
-                : 'text-text-muted hover:text-text-secondary'
-            }`}
-            onClick={() => setActiveTab('fragment')}
-          >
-            fragment.glsl
-          </button>
-          <button
-            class={`px-4 py-2 text-xs font-medium transition ${
-              activeTab() === 'vertex'
-                ? 'border-b-2 border-accent text-text-primary'
-                : 'text-text-muted hover:text-text-secondary'
-            }`}
-            onClick={() => setActiveTab('vertex')}
-          >
-            vertex.glsl
-          </button>
+          {props.session.language === 'tsl' ? (
+            <button
+              class="border-b-2 border-accent px-4 py-2 text-xs font-medium text-text-primary"
+            >
+              source.ts
+            </button>
+          ) : (
+            <>
+              <button
+                class={`px-4 py-2 text-xs font-medium transition ${
+                  activeTab() === 'fragment'
+                    ? 'border-b-2 border-accent text-text-primary'
+                    : 'text-text-muted hover:text-text-secondary'
+                }`}
+                onClick={() => setActiveTab('fragment')}
+              >
+                fragment.glsl
+              </button>
+              <button
+                class={`px-4 py-2 text-xs font-medium transition ${
+                  activeTab() === 'vertex'
+                    ? 'border-b-2 border-accent text-text-primary'
+                    : 'text-text-muted hover:text-text-secondary'
+                }`}
+                onClick={() => setActiveTab('vertex')}
+              >
+                vertex.glsl
+              </button>
+            </>
+          )}
+          <div class="ml-auto flex items-center px-3">
+            <span class="rounded bg-surface-card px-1.5 py-0.5 text-[10px] font-medium uppercase text-text-muted">
+              {props.session.language === 'tsl' ? 'TSL' : 'GLSL'}
+            </span>
+          </div>
         </div>
 
         {/* Editor */}
@@ -147,6 +176,7 @@ export default function PlaygroundLayout(props: PlaygroundLayoutProps) {
               vertexSource={vertexSource()}
               fragmentSource={fragmentSource()}
               pipeline={props.session.pipeline}
+              language={props.session.language}
               onError={handleErrors}
               onScreenshotReady={handleScreenshotReady}
             />

--- a/apps/web/src/lib/playground-types.ts
+++ b/apps/web/src/lib/playground-types.ts
@@ -18,14 +18,32 @@ export type SessionMetadata = {
   tags?: string[]
 }
 
+// ---------------------------------------------------------------------------
+// Structured errors
+// ---------------------------------------------------------------------------
+
+export type PlaygroundError =
+  | { kind: 'glsl-compile'; message: string }
+  | { kind: 'glsl-link'; message: string }
+  | { kind: 'tsl-parse'; message: string }
+  | { kind: 'tsl-runtime'; message: string }
+  | { kind: 'tsl-material-build'; message: string }
+
+// ---------------------------------------------------------------------------
+// Session types
+// ---------------------------------------------------------------------------
+
 export type PlaygroundSession = {
   id: string
+  language: 'glsl' | 'tsl'
   vertexSource: string
   fragmentSource: string
+  tslSource: string | null
   uniforms: UniformDefinition[]
   uniformValues: Record<string, unknown> | null
   pipeline: string
   compilationErrors: string[]
+  structuredErrors: PlaygroundError[]
   screenshotBase64: string | null
   screenshotAt: string | null
   metadata: SessionMetadata | null
@@ -39,8 +57,10 @@ export type PlaygroundSession = {
 
 export type ShaderUpdateEvent = {
   type: 'shader_update'
+  language: 'glsl' | 'tsl'
   vertexSource: string
   fragmentSource: string
+  tslSource: string | null
 }
 
 export type UniformUpdateEvent = {
@@ -55,8 +75,10 @@ export type PlaygroundSSEEvent = ShaderUpdateEvent | UniformUpdateEvent
 // ---------------------------------------------------------------------------
 
 export type CreateSessionRequest = {
+  language?: 'glsl' | 'tsl'
   vertexSource?: string
   fragmentSource?: string
+  tslSource?: string
   uniforms?: UniformDefinition[]
   pipeline?: string
 }
@@ -69,11 +91,13 @@ export type CreateSessionResponse = {
 export type UpdateShaderRequest = {
   vertexSource?: string
   fragmentSource?: string
+  tslSource?: string
 }
 
 export type UpdateShaderResponse = {
   status: 'ok'
   compilationErrors: string[]
+  structuredErrors: PlaygroundError[]
   screenshotBase64: string | null
   browserConnected: boolean
 }
@@ -84,4 +108,5 @@ export type ScreenshotRequest = {
 
 export type ErrorsResponse = {
   errors: string[]
+  structuredErrors: PlaygroundError[]
 }

--- a/apps/web/src/lib/playground-types.ts
+++ b/apps/web/src/lib/playground-types.ts
@@ -30,15 +30,11 @@ export type PlaygroundError =
   | { kind: 'tsl-material-build'; message: string }
 
 // ---------------------------------------------------------------------------
-// Session types
+// Session types — discriminated union on language
 // ---------------------------------------------------------------------------
 
-export type PlaygroundSession = {
+type PlaygroundSessionBase = {
   id: string
-  language: 'glsl' | 'tsl'
-  vertexSource: string
-  fragmentSource: string
-  tslSource: string | null
   uniforms: UniformDefinition[]
   uniformValues: Record<string, unknown> | null
   pipeline: string
@@ -51,17 +47,26 @@ export type PlaygroundSession = {
   updatedAt: string
 }
 
+export type GlslPlaygroundSession = PlaygroundSessionBase & {
+  language: 'glsl'
+  vertexSource: string
+  fragmentSource: string
+}
+
+export type TslPlaygroundSession = PlaygroundSessionBase & {
+  language: 'tsl'
+  tslSource: string
+}
+
+export type PlaygroundSession = GlslPlaygroundSession | TslPlaygroundSession
+
 // ---------------------------------------------------------------------------
 // SSE event types
 // ---------------------------------------------------------------------------
 
-export type ShaderUpdateEvent = {
-  type: 'shader_update'
-  language: 'glsl' | 'tsl'
-  vertexSource: string
-  fragmentSource: string
-  tslSource: string | null
-}
+export type ShaderUpdateEvent =
+  | { type: 'shader_update'; language: 'glsl'; vertexSource: string; fragmentSource: string }
+  | { type: 'shader_update'; language: 'tsl'; tslSource: string }
 
 export type UniformUpdateEvent = {
   type: 'uniform_update'
@@ -74,18 +79,27 @@ export type PlaygroundSSEEvent = ShaderUpdateEvent | UniformUpdateEvent
 // API request / response types
 // ---------------------------------------------------------------------------
 
-export type CreateSessionRequest = {
-  language?: 'glsl' | 'tsl'
+export type CreateGlslSessionRequest = {
+  language?: 'glsl'
   vertexSource?: string
   fragmentSource?: string
+  uniforms?: UniformDefinition[]
+  pipeline?: string
+}
+
+export type CreateTslSessionRequest = {
+  language: 'tsl'
   tslSource?: string
   uniforms?: UniformDefinition[]
   pipeline?: string
 }
 
+export type CreateSessionRequest = CreateGlslSessionRequest | CreateTslSessionRequest
+
 export type CreateSessionResponse = {
   sessionId: string
   url: string
+  previewAvailable: boolean
 }
 
 export type UpdateShaderRequest = {
@@ -100,6 +114,7 @@ export type UpdateShaderResponse = {
   structuredErrors: PlaygroundError[]
   screenshotBase64: string | null
   browserConnected: boolean
+  previewAvailable: boolean
 }
 
 export type ScreenshotRequest = {

--- a/apps/web/src/lib/server/load-shader-detail.ts
+++ b/apps/web/src/lib/server/load-shader-detail.ts
@@ -25,7 +25,7 @@ export type ShaderDetailRecipe = {
   requirements: string[]
 }
 
-export type ShaderDetail = {
+type ShaderDetailBase = {
   name: string
   displayName: string
   version: string
@@ -46,8 +46,6 @@ export type ShaderDetail = {
   uniforms: ShaderDetailUniform[]
   inputs: Array<{ name: string; kind: string; description: string; required: boolean }>
   outputs: Array<{ name: string; kind: string; description: string }>
-  vertexSource: string
-  fragmentSource: string
   recipes: ShaderDetailRecipe[]
   previewSvg: string | null
   provenance: {
@@ -69,6 +67,19 @@ export type ShaderDetail = {
   }
 }
 
+export type GlslShaderDetail = ShaderDetailBase & {
+  language: 'glsl'
+  vertexSource: string
+  fragmentSource: string
+}
+
+export type TslShaderDetail = ShaderDetailBase & {
+  language: 'tsl'
+  tslSource: string
+}
+
+export type ShaderDetail = GlslShaderDetail | TslShaderDetail
+
 /**
  * Load a single shader's full detail from its directory on disk.
  * This is the pure filesystem logic extracted from the getShaderDetail server function.
@@ -77,18 +88,13 @@ export async function loadShaderDetail(shaderDir: string): Promise<ShaderDetail>
   const manifestRaw = await readFile(join(shaderDir, 'shader.json'), 'utf8')
   const manifest = JSON.parse(manifestRaw) as Record<string, unknown>
 
-  const files = manifest.files as { vertex: string; fragment: string }
+  const language = (manifest.language as string) ?? 'glsl'
   const capabilityProfile = manifest.capabilityProfile as Record<string, unknown>
   const compatibility = manifest.compatibility as Record<string, unknown>
   const provenance = manifest.provenance as Record<string, unknown>
   const attribution = provenance.attribution as Record<string, unknown>
   const preview = manifest.preview as { path: string; format: string }
   const recipeMeta = manifest.recipes as Array<Record<string, unknown>>
-
-  const [vertexSource, fragmentSource] = await Promise.all([
-    readFile(join(shaderDir, files.vertex), 'utf8'),
-    readFile(join(shaderDir, files.fragment), 'utf8'),
-  ])
 
   const recipes: ShaderDetailRecipe[] = await Promise.all(
     recipeMeta.map(async (r) => {
@@ -109,13 +115,13 @@ export async function loadShaderDetail(shaderDir: string): Promise<ShaderDetail>
     previewSvg = await readFile(join(shaderDir, preview.path), 'utf8')
   }
 
-  return {
+  const base: Omit<ShaderDetail, 'language' | 'vertexSource' | 'fragmentSource' | 'tslSource'> = {
     name: manifest.name as string,
     displayName: manifest.displayName as string,
     version: manifest.version as string,
     summary: manifest.summary as string,
     description: manifest.description as string,
-    author: manifest.author as ShaderDetail['author'],
+    author: manifest.author as ShaderDetailBase['author'],
     license: manifest.license as string,
     tags: manifest.tags as string[],
     category: manifest.category as string,
@@ -128,15 +134,13 @@ export async function loadShaderDetail(shaderDir: string): Promise<ShaderDetail>
     material: compatibility.material as string,
     environments: compatibility.environments as string[],
     uniforms: manifest.uniforms as ShaderDetailUniform[],
-    inputs: manifest.inputs as ShaderDetail['inputs'],
-    outputs: manifest.outputs as ShaderDetail['outputs'],
-    vertexSource,
-    fragmentSource,
+    inputs: manifest.inputs as ShaderDetailBase['inputs'],
+    outputs: manifest.outputs as ShaderDetailBase['outputs'],
     recipes,
     previewSvg,
     provenance: {
       sourceKind: provenance.sourceKind as string,
-      sources: (provenance.sources as ShaderDetail['provenance']['sources']) ?? [],
+      sources: (provenance.sources as ShaderDetailBase['provenance']['sources']) ?? [],
       attribution: {
         summary: attribution.summary as string,
         requiredNotice: attribution.requiredNotice as string | undefined,
@@ -144,4 +148,17 @@ export async function loadShaderDetail(shaderDir: string): Promise<ShaderDetail>
       notes: provenance.notes as string | undefined,
     },
   }
+
+  if (language === 'tsl') {
+    const tslEntry = manifest.tslEntry as string
+    const tslSource = await readFile(join(shaderDir, tslEntry), 'utf8')
+    return { ...base, language: 'tsl', tslSource }
+  }
+
+  const files = manifest.files as { vertex: string; fragment: string }
+  const [vertexSource, fragmentSource] = await Promise.all([
+    readFile(join(shaderDir, files.vertex), 'utf8'),
+    readFile(join(shaderDir, files.fragment), 'utf8'),
+  ])
+  return { ...base, language: 'glsl', vertexSource, fragmentSource }
 }

--- a/apps/web/src/lib/server/playground-db.test.node.ts
+++ b/apps/web/src/lib/server/playground-db.test.node.ts
@@ -188,4 +188,18 @@ runTest('updateMetadata stores metadata', () => {
   assert.deepEqual(session.metadata, metadata)
 })
 
+runTest('createSession rejects invalid language', () => {
+  assert.throws(
+    () => createSession({ language: 'foo' as 'glsl' }),
+    /Invalid language "foo"/,
+  )
+})
+
+runTest('createSession rejects arbitrary language strings', () => {
+  assert.throws(
+    () => createSession({ language: 'wgsl' as 'glsl' }),
+    /Invalid language "wgsl"/,
+  )
+})
+
 console.log('playground-db tests passed')

--- a/apps/web/src/lib/server/playground-db.test.node.ts
+++ b/apps/web/src/lib/server/playground-db.test.node.ts
@@ -3,7 +3,6 @@ import { mkdtempSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
-// Isolate test DB in a temp directory so runs are idempotent
 process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'playground-test-'))
 
 const {
@@ -12,6 +11,7 @@ const {
   updateShader,
   setScreenshot,
   setErrors,
+  setStructuredErrors,
   setUniformValues,
   updateMetadata,
 } = await import('./playground-db.ts')
@@ -31,21 +31,18 @@ function runTest(name: string, callback: () => void | Promise<void>) {
   console.log(`ok ${name}`)
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
-runTest('createSession returns id and session with defaults', () => {
+runTest('createSession returns default GLSL session', () => {
   const { id, session } = createSession()
   assert.equal(typeof id, 'string')
-  assert.ok(id.length > 0)
   assert.equal(session.id, id)
+  assert.equal(session.language, 'glsl')
   assert.ok(session.vertexSource.includes('gl_Position'))
   assert.ok(session.fragmentSource.includes('gl_FragColor'))
   assert.equal(session.pipeline, 'surface')
   assert.equal(session.uniforms.length, 1)
   assert.equal(session.uniforms[0]!.name, 'uTime')
   assert.deepEqual(session.compilationErrors, [])
+  assert.deepEqual(session.structuredErrors, [])
   assert.equal(session.screenshotBase64, null)
   assert.equal(session.metadata, null)
 })
@@ -57,57 +54,96 @@ runTest('createSession accepts custom GLSL', () => {
     pipeline: 'postprocessing',
     uniforms: [{ name: 'uColor', type: 'vec3', defaultValue: [1, 0, 0] }],
   })
+  assert.equal(session.language, 'glsl')
   assert.ok(session.vertexSource.includes('vec4(0.0)'))
   assert.ok(session.fragmentSource.includes('1.0, 0.0, 0.0'))
   assert.equal(session.pipeline, 'postprocessing')
-  assert.equal(session.uniforms.length, 1)
-  assert.equal(session.uniforms[0]!.name, 'uColor')
+})
+
+runTest('createSession accepts TSL without GLSL payloads', () => {
+  const { session } = createSession({
+    language: 'tsl',
+    tslSource: 'export function createMaterial() {}',
+    pipeline: 'geometry',
+  })
+  assert.equal(session.language, 'tsl')
+  assert.equal(session.tslSource, 'export function createMaterial() {}')
+  assert.equal(session.pipeline, 'geometry')
+})
+
+runTest('createSession rejects tslSource on GLSL sessions', () => {
+  assert.throws(
+    () => createSession({ tslSource: 'export function createMaterial() {}' }),
+    /GLSL sessions do not accept tslSource/,
+  )
+})
+
+runTest('createSession rejects GLSL source fields on TSL sessions', () => {
+  assert.throws(
+    () =>
+      createSession({
+        language: 'tsl',
+        tslSource: 'export function createMaterial() {}',
+        vertexSource: 'void main() {}',
+      }),
+    /TSL sessions do not accept vertexSource/,
+  )
+})
+
+runTest('createSession rejects TSL postprocessing sessions', () => {
+  assert.throws(
+    () =>
+      createSession({
+        language: 'tsl',
+        tslSource: 'export function createMaterial() {}',
+        pipeline: 'postprocessing',
+      }),
+    /TSL sessions do not support the postprocessing pipeline/,
+  )
 })
 
 runTest('getSession returns null for unknown id', () => {
-  const session = getSession('nonexistent-id')
-  assert.equal(session, null)
+  assert.equal(getSession('nonexistent-id'), null)
 })
 
-runTest('getSession returns created session', () => {
+runTest('updateShader updates GLSL sources', () => {
   const { id } = createSession()
-  const session = getSession(id)
-  assert.ok(session)
-  assert.equal(session.id, id)
-})
-
-runTest('updateShader updates vertex source', () => {
-  const { id } = createSession()
-  const newVertex = 'void main() { gl_Position = vec4(1.0); }'
-  updateShader(id, { vertexSource: newVertex })
+  updateShader(id, { vertexSource: 'vertex shader', fragmentSource: 'fragment shader' }, 'glsl')
   const session = getSession(id)!
-  assert.equal(session.vertexSource, newVertex)
-  // Fragment should remain the default
-  assert.ok(session.fragmentSource.includes('gl_FragColor'))
+  assert.equal(session.language, 'glsl')
+  assert.equal(session.vertexSource, 'vertex shader')
+  assert.equal(session.fragmentSource, 'fragment shader')
 })
 
-runTest('updateShader updates fragment source', () => {
-  const { id } = createSession()
-  const newFrag = 'void main() { gl_FragColor = vec4(0.0); }'
-  updateShader(id, { fragmentSource: newFrag })
+runTest('updateShader updates TSL source', () => {
+  const { id } = createSession({ language: 'tsl', tslSource: 'old tsl' })
+  updateShader(id, { tslSource: 'new tsl' }, 'tsl')
   const session = getSession(id)!
-  assert.equal(session.fragmentSource, newFrag)
+  assert.equal(session.language, 'tsl')
+  assert.equal(session.tslSource, 'new tsl')
 })
 
-runTest('updateShader updates both sources', () => {
+runTest('updateShader rejects mismatched GLSL fields for TSL sessions', () => {
+  const { id } = createSession({ language: 'tsl', tslSource: 'old tsl' })
+  assert.throws(
+    () => updateShader(id, { vertexSource: 'bad' }, 'tsl'),
+    /TSL sessions do not accept vertexSource updates/,
+  )
+})
+
+runTest('updateShader rejects mismatched TSL fields for GLSL sessions', () => {
   const { id } = createSession()
-  const newVertex = 'vertex shader'
-  const newFrag = 'fragment shader'
-  updateShader(id, { vertexSource: newVertex, fragmentSource: newFrag })
-  const session = getSession(id)!
-  assert.equal(session.vertexSource, newVertex)
-  assert.equal(session.fragmentSource, newFrag)
+  assert.throws(
+    () => updateShader(id, { tslSource: 'bad' }, 'glsl'),
+    /GLSL sessions do not accept tslSource updates/,
+  )
 })
 
 runTest('updateShader with empty object is a no-op', () => {
   const { id, session: original } = createSession()
-  updateShader(id, {})
+  updateShader(id, {}, 'glsl')
   const session = getSession(id)!
+  assert.equal(session.language, 'glsl')
   assert.equal(session.vertexSource, original.vertexSource)
   assert.equal(session.fragmentSource, original.fragmentSource)
 })
@@ -128,12 +164,12 @@ runTest('setErrors stores compilation errors', () => {
   assert.deepEqual(session.compilationErrors, errors)
 })
 
-runTest('setErrors with empty array clears errors', () => {
-  const { id } = createSession()
-  setErrors(id, ['some error'])
-  setErrors(id, [])
+runTest('setStructuredErrors stores structured errors', () => {
+  const { id } = createSession({ language: 'tsl', tslSource: 'export function createMaterial() {}' })
+  const errors = [{ kind: 'tsl-runtime', message: 'createMaterial failed' }] as const
+  setStructuredErrors(id, [...errors])
   const session = getSession(id)!
-  assert.deepEqual(session.compilationErrors, [])
+  assert.deepEqual(session.structuredErrors, errors)
 })
 
 runTest('setUniformValues stores values', () => {
@@ -150,23 +186,6 @@ runTest('updateMetadata stores metadata', () => {
   updateMetadata(id, metadata)
   const session = getSession(id)!
   assert.deepEqual(session.metadata, metadata)
-})
-
-runTest('updateMetadata overwrites previous metadata', () => {
-  const { id } = createSession()
-  updateMetadata(id, { name: 'old' })
-  updateMetadata(id, { name: 'new', tags: ['updated'] })
-  const session = getSession(id)!
-  assert.equal(session.metadata!.name, 'new')
-  assert.deepEqual(session.metadata!.tags, ['updated'])
-})
-
-runTest('multiple sessions are independent', () => {
-  const { id: id1 } = createSession({ fragmentSource: 'shader1' })
-  const { id: id2 } = createSession({ fragmentSource: 'shader2' })
-  assert.notEqual(id1, id2)
-  assert.equal(getSession(id1)!.fragmentSource, 'shader1')
-  assert.equal(getSession(id2)!.fragmentSource, 'shader2')
 })
 
 console.log('playground-db tests passed')

--- a/apps/web/src/lib/server/playground-db.ts
+++ b/apps/web/src/lib/server/playground-db.ts
@@ -34,6 +34,48 @@ const DEFAULT_UNIFORMS: UniformDefinition[] = [
   { name: 'uTime', type: 'float', defaultValue: 0, description: 'Elapsed time in seconds' },
 ]
 
+function validateCreateSessionRequest(opts?: CreateSessionRequest) {
+  const language = opts?.language ?? 'glsl'
+
+  if (language === 'glsl') {
+    if ('tslSource' in (opts ?? {}) && opts?.tslSource !== undefined) {
+      throw new Error('GLSL sessions do not accept tslSource')
+    }
+    return
+  }
+
+  if ('vertexSource' in (opts ?? {}) && opts?.vertexSource !== undefined) {
+    throw new Error('TSL sessions do not accept vertexSource')
+  }
+
+  if ('fragmentSource' in (opts ?? {}) && opts?.fragmentSource !== undefined) {
+    throw new Error('TSL sessions do not accept fragmentSource')
+  }
+
+  if (opts?.pipeline === 'postprocessing') {
+    throw new Error('TSL sessions do not support the postprocessing pipeline')
+  }
+}
+
+function validateUpdateShaderRequest(
+  update: { vertexSource?: string; fragmentSource?: string; tslSource?: string },
+  sessionLanguage: 'glsl' | 'tsl',
+) {
+  if (sessionLanguage === 'glsl' && update.tslSource !== undefined) {
+    throw new Error('GLSL sessions do not accept tslSource updates')
+  }
+
+  if (sessionLanguage === 'tsl') {
+    if (update.vertexSource !== undefined) {
+      throw new Error('TSL sessions do not accept vertexSource updates')
+    }
+
+    if (update.fragmentSource !== undefined) {
+      throw new Error('TSL sessions do not accept fragmentSource updates')
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Database setup
 // ---------------------------------------------------------------------------
@@ -178,12 +220,8 @@ type SessionRow = {
 }
 
 function rowToSession(row: SessionRow): PlaygroundSession {
-  return {
+  const base = {
     id: row.id,
-    language: row.shader_language as 'glsl' | 'tsl',
-    vertexSource: row.vertex_source,
-    fragmentSource: row.fragment_source,
-    tslSource: row.tsl_source,
     uniforms: JSON.parse(row.uniforms_json) as UniformDefinition[],
     uniformValues: row.uniform_values_json ? (JSON.parse(row.uniform_values_json) as Record<string, unknown>) : null,
     pipeline: row.pipeline,
@@ -199,6 +237,11 @@ function rowToSession(row: SessionRow): PlaygroundSession {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
+
+  if (row.shader_language === 'tsl') {
+    return { ...base, language: 'tsl', tslSource: row.tsl_source ?? '' }
+  }
+  return { ...base, language: 'glsl', vertexSource: row.vertex_source, fragmentSource: row.fragment_source }
 }
 
 // ---------------------------------------------------------------------------
@@ -206,13 +249,23 @@ function rowToSession(row: SessionRow): PlaygroundSession {
 // ---------------------------------------------------------------------------
 
 export function createSession(opts?: CreateSessionRequest): { id: string; session: PlaygroundSession } {
+  validateCreateSessionRequest(opts)
+
   const id = randomUUID()
   const language = opts?.language ?? 'glsl'
-  const vertexSource = opts?.vertexSource ?? DEFAULT_VERTEX
-  const fragmentSource = opts?.fragmentSource ?? DEFAULT_FRAGMENT
-  const tslSource = opts?.tslSource ?? null
   const uniforms = opts?.uniforms ?? DEFAULT_UNIFORMS
   const pipeline = opts?.pipeline ?? 'surface'
+
+  // Language-specific source defaults — TSL sessions don't carry GLSL payloads
+  const vertexSource = language === 'glsl'
+    ? ((opts as { vertexSource?: string })?.vertexSource ?? DEFAULT_VERTEX)
+    : ''
+  const fragmentSource = language === 'glsl'
+    ? ((opts as { fragmentSource?: string })?.fragmentSource ?? DEFAULT_FRAGMENT)
+    : ''
+  const tslSource = language === 'tsl'
+    ? ((opts as { tslSource?: string })?.tslSource ?? null)
+    : null
 
   db.prepare(
     `INSERT INTO playground_sessions (id, shader_language, vertex_source, fragment_source, tsl_source, uniforms_json, pipeline)
@@ -231,21 +284,30 @@ export function getSession(id: string): PlaygroundSession | null {
   return rowToSession(row)
 }
 
-export function updateShader(id: string, update: { vertexSource?: string; fragmentSource?: string; tslSource?: string }): void {
+export function updateShader(
+  id: string,
+  update: { vertexSource?: string; fragmentSource?: string; tslSource?: string },
+  sessionLanguage: 'glsl' | 'tsl',
+): void {
+  validateUpdateShaderRequest(update, sessionLanguage)
+
   const parts: string[] = []
   const values: unknown[] = []
 
-  if (update.vertexSource !== undefined) {
-    parts.push('vertex_source = ?')
-    values.push(update.vertexSource)
-  }
-  if (update.fragmentSource !== undefined) {
-    parts.push('fragment_source = ?')
-    values.push(update.fragmentSource)
-  }
-  if (update.tslSource !== undefined) {
-    parts.push('tsl_source = ?')
-    values.push(update.tslSource)
+  if (sessionLanguage === 'glsl') {
+    if (update.vertexSource !== undefined) {
+      parts.push('vertex_source = ?')
+      values.push(update.vertexSource)
+    }
+    if (update.fragmentSource !== undefined) {
+      parts.push('fragment_source = ?')
+      values.push(update.fragmentSource)
+    }
+  } else {
+    if (update.tslSource !== undefined) {
+      parts.push('tsl_source = ?')
+      values.push(update.tslSource)
+    }
   }
 
   if (parts.length === 0) return
@@ -258,13 +320,10 @@ export function updateShader(id: string, update: { vertexSource?: string; fragme
   // Push SSE update to connected browsers
   const session = getSession(id)
   if (session) {
-    pushSSEEvent(id, {
-      type: 'shader_update',
-      language: session.language,
-      vertexSource: session.vertexSource,
-      fragmentSource: session.fragmentSource,
-      tslSource: session.tslSource,
-    })
+    const event: PlaygroundSSEEvent = session.language === 'tsl'
+      ? { type: 'shader_update', language: 'tsl', tslSource: session.tslSource }
+      : { type: 'shader_update', language: 'glsl', vertexSource: session.vertexSource, fragmentSource: session.fragmentSource }
+    pushSSEEvent(id, event)
   }
 }
 

--- a/apps/web/src/lib/server/playground-db.ts
+++ b/apps/web/src/lib/server/playground-db.ts
@@ -4,6 +4,7 @@ import { dirname, resolve } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import type {
   PlaygroundSession,
+  PlaygroundError,
   UniformDefinition,
   SessionMetadata,
   CreateSessionRequest,
@@ -59,6 +60,23 @@ db.exec(`
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
   )
 `)
+
+// Schema migration: add TSL columns
+try {
+  db.exec(`ALTER TABLE playground_sessions ADD COLUMN shader_language TEXT NOT NULL DEFAULT 'glsl'`)
+} catch {
+  // Column already exists
+}
+try {
+  db.exec(`ALTER TABLE playground_sessions ADD COLUMN tsl_source TEXT`)
+} catch {
+  // Column already exists
+}
+try {
+  db.exec(`ALTER TABLE playground_sessions ADD COLUMN structured_errors_json TEXT`)
+} catch {
+  // Column already exists
+}
 
 // ---------------------------------------------------------------------------
 // SSE connection registry (in-memory, ephemeral)
@@ -143,12 +161,15 @@ export function resolveScreenshotWaiters(sessionId: string, base64: string) {
 
 type SessionRow = {
   id: string
+  shader_language: string
   vertex_source: string
   fragment_source: string
+  tsl_source: string | null
   uniforms_json: string
   uniform_values_json: string | null
   pipeline: string
   compilation_errors_json: string | null
+  structured_errors_json: string | null
   screenshot_base64: string | null
   screenshot_at: string | null
   metadata_json: string | null
@@ -159,13 +180,18 @@ type SessionRow = {
 function rowToSession(row: SessionRow): PlaygroundSession {
   return {
     id: row.id,
+    language: row.shader_language as 'glsl' | 'tsl',
     vertexSource: row.vertex_source,
     fragmentSource: row.fragment_source,
+    tslSource: row.tsl_source,
     uniforms: JSON.parse(row.uniforms_json) as UniformDefinition[],
     uniformValues: row.uniform_values_json ? (JSON.parse(row.uniform_values_json) as Record<string, unknown>) : null,
     pipeline: row.pipeline,
     compilationErrors: row.compilation_errors_json
       ? (JSON.parse(row.compilation_errors_json) as string[])
+      : [],
+    structuredErrors: row.structured_errors_json
+      ? (JSON.parse(row.structured_errors_json) as PlaygroundError[])
       : [],
     screenshotBase64: row.screenshot_base64,
     screenshotAt: row.screenshot_at,
@@ -181,15 +207,17 @@ function rowToSession(row: SessionRow): PlaygroundSession {
 
 export function createSession(opts?: CreateSessionRequest): { id: string; session: PlaygroundSession } {
   const id = randomUUID()
+  const language = opts?.language ?? 'glsl'
   const vertexSource = opts?.vertexSource ?? DEFAULT_VERTEX
   const fragmentSource = opts?.fragmentSource ?? DEFAULT_FRAGMENT
+  const tslSource = opts?.tslSource ?? null
   const uniforms = opts?.uniforms ?? DEFAULT_UNIFORMS
   const pipeline = opts?.pipeline ?? 'surface'
 
   db.prepare(
-    `INSERT INTO playground_sessions (id, vertex_source, fragment_source, uniforms_json, pipeline)
-     VALUES (?, ?, ?, ?, ?)`,
-  ).run(id, vertexSource, fragmentSource, JSON.stringify(uniforms), pipeline)
+    `INSERT INTO playground_sessions (id, shader_language, vertex_source, fragment_source, tsl_source, uniforms_json, pipeline)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(id, language, vertexSource, fragmentSource, tslSource, JSON.stringify(uniforms), pipeline)
 
   const session = getSession(id)!
   return { id, session }
@@ -203,7 +231,7 @@ export function getSession(id: string): PlaygroundSession | null {
   return rowToSession(row)
 }
 
-export function updateShader(id: string, update: { vertexSource?: string; fragmentSource?: string }): void {
+export function updateShader(id: string, update: { vertexSource?: string; fragmentSource?: string; tslSource?: string }): void {
   const parts: string[] = []
   const values: unknown[] = []
 
@@ -214,6 +242,10 @@ export function updateShader(id: string, update: { vertexSource?: string; fragme
   if (update.fragmentSource !== undefined) {
     parts.push('fragment_source = ?')
     values.push(update.fragmentSource)
+  }
+  if (update.tslSource !== undefined) {
+    parts.push('tsl_source = ?')
+    values.push(update.tslSource)
   }
 
   if (parts.length === 0) return
@@ -228,8 +260,10 @@ export function updateShader(id: string, update: { vertexSource?: string; fragme
   if (session) {
     pushSSEEvent(id, {
       type: 'shader_update',
+      language: session.language,
       vertexSource: session.vertexSource,
       fragmentSource: session.fragmentSource,
+      tslSource: session.tslSource,
     })
   }
 }
@@ -246,6 +280,12 @@ export function setScreenshot(id: string, base64: string): void {
 export function setErrors(id: string, errors: string[]): void {
   db.prepare(
     `UPDATE playground_sessions SET compilation_errors_json = ?, updated_at = datetime('now') WHERE id = ?`,
+  ).run(JSON.stringify(errors), id)
+}
+
+export function setStructuredErrors(id: string, errors: PlaygroundError[]): void {
+  db.prepare(
+    `UPDATE playground_sessions SET structured_errors_json = ?, updated_at = datetime('now') WHERE id = ?`,
   ).run(JSON.stringify(errors), id)
 }
 

--- a/apps/web/src/lib/server/playground-db.ts
+++ b/apps/web/src/lib/server/playground-db.ts
@@ -34,8 +34,14 @@ const DEFAULT_UNIFORMS: UniformDefinition[] = [
   { name: 'uTime', type: 'float', defaultValue: 0, description: 'Elapsed time in seconds' },
 ]
 
+const VALID_LANGUAGES = new Set(['glsl', 'tsl'])
+
 function validateCreateSessionRequest(opts?: CreateSessionRequest) {
   const language = opts?.language ?? 'glsl'
+
+  if (!VALID_LANGUAGES.has(language)) {
+    throw new Error(`Invalid language "${language}". Must be "glsl" or "tsl".`)
+  }
 
   if (language === 'glsl') {
     if ('tslSource' in (opts ?? {}) && opts?.tslSource !== undefined) {

--- a/apps/web/src/lib/server/shader-detail.ts
+++ b/apps/web/src/lib/server/shader-detail.ts
@@ -3,6 +3,8 @@ import { getShaderDetailFromSource } from './shader-source.ts'
 
 export type {
   ShaderDetail,
+  GlslShaderDetail,
+  TslShaderDetail,
   ShaderDetailUniform,
   ShaderDetailRecipe,
 } from './load-shader-detail.ts'

--- a/apps/web/src/lib/server/shader-source.ts
+++ b/apps/web/src/lib/server/shader-source.ts
@@ -1,5 +1,5 @@
 import type { ShaderEntry } from './list-shaders.ts'
-import type { ShaderDetail, ShaderDetailRecipe } from './load-shader-detail.ts'
+import type { ShaderDetail, ShaderDetailRecipe, GlslShaderDetail, TslShaderDetail } from './load-shader-detail.ts'
 
 /**
  * Environment-aware shader data source.
@@ -62,13 +62,15 @@ export async function getShaderDetailFromSource(name: string): Promise<ShaderDet
       }),
     )
 
-    return {
+    const language = (bundle.language as string) ?? 'glsl'
+
+    const base = {
       name: bundle.name as string,
       displayName: bundle.displayName as string,
       version: bundle.version as string,
       summary: bundle.summary as string,
       description: bundle.description as string,
-      author: bundle.author as ShaderDetail['author'],
+      author: bundle.author as GlslShaderDetail['author'],
       license: bundle.license as string,
       tags: bundle.tags as string[],
       category: bundle.category as string,
@@ -81,22 +83,30 @@ export async function getShaderDetailFromSource(name: string): Promise<ShaderDet
       material: compatibility.material as string,
       environments: compatibility.environments as string[],
       uniforms: uniformsFull,
-      inputs: bundle.inputs as ShaderDetail['inputs'],
-      outputs: bundle.outputs as ShaderDetail['outputs'],
-      vertexSource: bundle.vertexSource as string,
-      fragmentSource: bundle.fragmentSource as string,
+      inputs: bundle.inputs as GlslShaderDetail['inputs'],
+      outputs: bundle.outputs as GlslShaderDetail['outputs'],
       recipes,
       // previewSvg is not available in the registry bundle
       previewSvg: null,
       provenance: {
         sourceKind: provenance.sourceKind as string,
-        sources: (provenance.sources as ShaderDetail['provenance']['sources']) ?? [],
+        sources: (provenance.sources as GlslShaderDetail['provenance']['sources']) ?? [],
         attribution: {
           summary: attribution.summary as string,
           requiredNotice: attribution.requiredNotice as string | undefined,
         },
         notes: provenance.notes as string | undefined,
       },
+    }
+
+    if (language === 'tsl') {
+      return { ...base, language: 'tsl' as const, tslSource: bundle.tslSource as string }
+    }
+    return {
+      ...base,
+      language: 'glsl' as const,
+      vertexSource: bundle.vertexSource as string,
+      fragmentSource: bundle.fragmentSource as string,
     }
   }
 

--- a/apps/web/src/lib/server/shaders.test.ts
+++ b/apps/web/src/lib/server/shaders.test.ts
@@ -23,6 +23,32 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const repoRoot = resolve(__dirname, '../../../../..')
 const shadersRoot = resolve(repoRoot, 'shaders')
+const shaderSourceModuleUrl = new URL('./shader-source.ts', import.meta.url)
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+async function importShaderSourceModule(
+  cacheBust: string,
+  registryUrl = 'https://registry.example',
+) {
+  const previousRegistryUrl = process.env.REGISTRY_URL
+  process.env.REGISTRY_URL = registryUrl
+
+  try {
+    return await import(`${shaderSourceModuleUrl.href}?${cacheBust}`)
+  } finally {
+    if (previousRegistryUrl === undefined) {
+      delete process.env.REGISTRY_URL
+    } else {
+      process.env.REGISTRY_URL = previousRegistryUrl
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // listShadersFromDisk tests
@@ -170,6 +196,134 @@ async function main() {
     assert.ok('vertexSource' in detail, 'GLSL detail should have vertexSource')
     assert.ok('fragmentSource' in detail, 'GLSL detail should have fragmentSource')
     assert.ok(!('tslSource' in detail), 'GLSL detail should not have tslSource')
+  })
+
+  await runTest('getShaderDetailFromSource â€” registry-backed TSL bundle returns tslSource', async () => {
+    const { getShaderDetailFromSource } = await importShaderSourceModule('registry-tsl')
+    const originalFetch = globalThis.fetch
+
+    globalThis.fetch = (async (input) => {
+      assert.equal(String(input), 'https://registry.example/shaders/tsl-gradient-wave.json')
+      return jsonResponse({
+        name: 'tsl-gradient-wave',
+        displayName: 'TSL Gradient Wave',
+        version: '0.1.0',
+        summary: 'Registry-backed TSL shader',
+        description: 'Registry-backed TSL shader detail',
+        author: { name: 'ShaderBase' },
+        license: 'MIT',
+        tags: ['tsl', 'wave'],
+        category: 'color',
+        language: 'tsl',
+        compatibility: {
+          three: '>=0.170.0',
+          renderers: ['webgpu'],
+          material: 'node-material',
+          environments: ['three'],
+        },
+        capabilityProfile: {
+          pipeline: 'surface',
+          stage: 'vertex-and-fragment',
+          requires: ['uv', 'time'],
+          outputs: ['color'],
+        },
+        uniformsFull: [],
+        inputs: [],
+        outputs: [{ name: 'surfaceColor', kind: 'color', description: 'Color output' }],
+        recipes: {
+          three: {
+            exportName: 'createTslGradientWaveMaterial',
+            summary: 'Create a TSL material',
+            code: 'export function createTslGradientWaveMaterial() {}',
+            placeholders: [],
+            requirements: ['three-scene'],
+          },
+        },
+        provenance: {
+          sourceKind: 'original',
+          sources: [],
+          attribution: { summary: 'Created in ShaderBase' },
+        },
+        tslSource: 'export function createMaterial() {}',
+      })
+    }) as typeof fetch
+
+    try {
+      const detail = await getShaderDetailFromSource('tsl-gradient-wave')
+      assert.equal(detail.language, 'tsl')
+      assert.ok('tslSource' in detail, 'TSL detail should have tslSource')
+      assert.equal(detail.tslSource, 'export function createMaterial() {}')
+      assert.ok(!('vertexSource' in detail), 'TSL detail should not have vertexSource')
+      assert.ok(!('fragmentSource' in detail), 'TSL detail should not have fragmentSource')
+      assert.equal(detail.previewSvg, null)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  await runTest('getShaderDetailFromSource â€” registry-backed GLSL bundle returns GLSL sources', async () => {
+    const { getShaderDetailFromSource } = await importShaderSourceModule('registry-glsl')
+    const originalFetch = globalThis.fetch
+
+    globalThis.fetch = (async (input) => {
+      assert.equal(String(input), 'https://registry.example/shaders/gradient-radial.json')
+      return jsonResponse({
+        name: 'gradient-radial',
+        displayName: 'Radial Gradient',
+        version: '0.1.0',
+        summary: 'Registry-backed GLSL shader',
+        description: 'Registry-backed GLSL shader detail',
+        author: { name: 'ShaderBase' },
+        license: 'MIT',
+        tags: ['glsl', 'gradient'],
+        category: 'color',
+        language: 'glsl',
+        compatibility: {
+          three: '>=0.160.0',
+          renderers: ['webgl2'],
+          material: 'shader-material',
+          environments: ['three', 'react-three-fiber'],
+        },
+        capabilityProfile: {
+          pipeline: 'surface',
+          stage: 'vertex-and-fragment',
+          requires: ['uv', 'time'],
+          outputs: ['color'],
+        },
+        uniformsFull: [],
+        inputs: [],
+        outputs: [{ name: 'color', kind: 'color', description: 'Color output' }],
+        recipes: {
+          three: {
+            exportName: 'createGradientRadialMaterial',
+            summary: 'Create a GLSL material',
+            code: 'export function createGradientRadialMaterial() {}',
+            placeholders: [],
+            requirements: ['three-scene'],
+          },
+        },
+        provenance: {
+          sourceKind: 'original',
+          sources: [],
+          attribution: { summary: 'Created in ShaderBase' },
+        },
+        vertexSource: 'void main() { gl_Position = vec4(position, 1.0); }',
+        fragmentSource: 'void main() { gl_FragColor = vec4(1.0); }',
+      })
+    }) as typeof fetch
+
+    try {
+      const detail = await getShaderDetailFromSource('gradient-radial')
+      assert.equal(detail.language, 'glsl')
+      assert.ok('vertexSource' in detail, 'GLSL detail should have vertexSource')
+      assert.ok('fragmentSource' in detail, 'GLSL detail should have fragmentSource')
+      assert.ok(!('tslSource' in detail), 'GLSL detail should not have tslSource')
+      assert.ok(detail.vertexSource.includes('gl_Position'))
+      assert.ok(detail.fragmentSource.includes('gl_FragColor'))
+      assert.equal(detail.previewSvg, null)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
   })
 
   console.log('shaders tests passed')

--- a/apps/web/src/lib/server/shaders.test.ts
+++ b/apps/web/src/lib/server/shaders.test.ts
@@ -132,6 +132,46 @@ async function main() {
     assert.ok(detail.previewSvg!.includes('<svg'), 'previewSvg should contain SVG markup')
   })
 
+  // ---------------------------------------------------------------------------
+  // TSL shader detail tests
+  // ---------------------------------------------------------------------------
+
+  await runTest('loadShaderDetail — loads TSL shader with tslSource', async () => {
+    const detail = await loadShaderDetail(resolve(shadersRoot, 'tsl-gradient-wave'))
+    assert.equal(detail.language, 'tsl')
+    assert.equal(detail.name, 'tsl-gradient-wave')
+    assert.equal(detail.displayName, 'TSL Gradient Wave')
+    assert.ok('tslSource' in detail, 'TSL detail should have tslSource')
+    assert.ok(detail.tslSource.includes('createMaterial'), 'tslSource should contain createMaterial')
+    assert.ok(!('vertexSource' in detail), 'TSL detail should not have vertexSource')
+    assert.ok(!('fragmentSource' in detail), 'TSL detail should not have fragmentSource')
+  })
+
+  await runTest('loadShaderDetail — TSL shader has correct metadata', async () => {
+    const detail = await loadShaderDetail(resolve(shadersRoot, 'tsl-gradient-wave'))
+    assert.equal(detail.category, 'color')
+    assert.equal(detail.pipeline, 'surface')
+    assert.equal(detail.material, 'node-material')
+    assert.deepEqual(detail.renderers, ['webgpu'])
+    assert.ok(detail.tags.includes('tsl'), 'Expected "tsl" tag')
+  })
+
+  await runTest('loadShaderDetail — TSL shader loads recipes', async () => {
+    const detail = await loadShaderDetail(resolve(shadersRoot, 'tsl-gradient-wave'))
+    assert.ok(detail.recipes.length >= 1, 'Expected at least 1 recipe')
+    const threeRecipe = detail.recipes.find((r) => r.target === 'three')
+    assert.ok(threeRecipe, 'Should have a "three" recipe')
+    assert.ok(threeRecipe.code.length > 0, 'recipe code should not be empty')
+  })
+
+  await runTest('loadShaderDetail — GLSL shader has language glsl', async () => {
+    const detail = await loadShaderDetail(resolve(shadersRoot, 'gradient-radial'))
+    assert.equal(detail.language, 'glsl')
+    assert.ok('vertexSource' in detail, 'GLSL detail should have vertexSource')
+    assert.ok('fragmentSource' in detail, 'GLSL detail should have fragmentSource')
+    assert.ok(!('tslSource' in detail), 'GLSL detail should not have tslSource')
+  })
+
   console.log('shaders tests passed')
 }
 

--- a/apps/web/src/routes/api/playground/$.ts
+++ b/apps/web/src/routes/api/playground/$.ts
@@ -40,6 +40,13 @@ function unauthorizedResponse(): Response {
   })
 }
 
+function badRequestResponse(message: string): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status: 400,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
 function jsonResponse(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
     status,
@@ -80,12 +87,17 @@ async function handlePlayground(request: Request): Promise<Response> {
   if (segments[0] === 'create' && request.method === 'POST') {
     if (!isAuthorized(request)) return unauthorizedResponse()
     const body = (await request.json().catch(() => ({}))) as CreateSessionRequest
-    const { id } = createSession(body)
-    const response: CreateSessionResponse = {
-      sessionId: id,
-      url: `${WEB_URL}/playground?session=${id}`,
+    try {
+      const created = createSession(body)
+      const response: CreateSessionResponse = {
+        sessionId: created.id,
+        url: `${WEB_URL}/playground?session=${created.id}`,
+        previewAvailable: created.session.language === 'glsl',
+      }
+      return jsonResponse(response, 201)
+    } catch (error) {
+      return badRequestResponse(error instanceof Error ? error.message : 'Invalid session request')
     }
-    return jsonResponse(response, 201)
   }
 
   // Routes that require a sessionId: /api/playground/:sessionId/:action
@@ -150,12 +162,18 @@ async function handlePlayground(request: Request): Promise<Response> {
     if (!session) return jsonResponse({ error: 'Session not found' }, 404)
 
     const body = (await request.json().catch(() => ({}))) as UpdateShaderRequest
-    updateShader(sessionId, body)
+    try {
+      updateShader(sessionId, body, session.language)
+    } catch (error) {
+      return badRequestResponse(error instanceof Error ? error.message : 'Invalid shader update request')
+    }
 
-    // Wait for screenshot from browser (with timeout)
+    const previewAvailable = session.language === 'glsl'
+
+    // Wait for screenshot from browser — only for GLSL (TSL preview not yet implemented)
     const browserConnected = hasSSEConnections(sessionId)
     let screenshotBase64: string | null = null
-    if (browserConnected) {
+    if (browserConnected && previewAvailable) {
       screenshotBase64 = await waitForScreenshot(sessionId, SCREENSHOT_WAIT_MS)
     }
 
@@ -167,6 +185,7 @@ async function handlePlayground(request: Request): Promise<Response> {
       structuredErrors: updated?.structuredErrors ?? [],
       screenshotBase64,
       browserConnected,
+      previewAvailable,
     }
     return jsonResponse(response)
   }
@@ -192,9 +211,7 @@ async function handlePlayground(request: Request): Promise<Response> {
       structuredErrors?: PlaygroundError[]
     }
     setErrors(sessionId, body.errors ?? [])
-    if (body.structuredErrors) {
-      setStructuredErrors(sessionId, body.structuredErrors)
-    }
+    setStructuredErrors(sessionId, body.structuredErrors ?? [])
     return jsonResponse({ status: 'ok' })
   }
 

--- a/apps/web/src/routes/api/playground/$.ts
+++ b/apps/web/src/routes/api/playground/$.ts
@@ -5,12 +5,14 @@ import {
   updateShader,
   setScreenshot,
   setErrors,
+  setStructuredErrors,
   hasSSEConnections,
   addSSEConnection,
   removeSSEConnection,
   waitForScreenshot,
 } from '../../../lib/server/playground-db'
 import type {
+  PlaygroundError,
   CreateSessionRequest,
   CreateSessionResponse,
   UpdateShaderRequest,
@@ -104,7 +106,10 @@ async function handlePlayground(request: Request): Promise<Response> {
   if (action === 'errors' && request.method === 'GET') {
     const session = getSession(sessionId)
     if (!session) return jsonResponse({ error: 'Session not found' }, 404)
-    const response: ErrorsResponse = { errors: session.compilationErrors }
+    const response: ErrorsResponse = {
+      errors: session.compilationErrors,
+      structuredErrors: session.structuredErrors,
+    }
     return jsonResponse(response)
   }
 
@@ -159,6 +164,7 @@ async function handlePlayground(request: Request): Promise<Response> {
     const response: UpdateShaderResponse = {
       status: 'ok',
       compilationErrors: updated?.compilationErrors ?? [],
+      structuredErrors: updated?.structuredErrors ?? [],
       screenshotBase64,
       browserConnected,
     }
@@ -181,8 +187,14 @@ async function handlePlayground(request: Request): Promise<Response> {
     const session = getSession(sessionId)
     if (!session) return jsonResponse({ error: 'Session not found' }, 404)
 
-    const body = (await request.json().catch(() => ({ errors: [] }))) as { errors: string[] }
+    const body = (await request.json().catch(() => ({ errors: [], structuredErrors: [] }))) as {
+      errors: string[]
+      structuredErrors?: PlaygroundError[]
+    }
     setErrors(sessionId, body.errors ?? [])
+    if (body.structuredErrors) {
+      setStructuredErrors(sessionId, body.structuredErrors)
+    }
     return jsonResponse({ status: 'ok' })
   }
 

--- a/apps/web/src/routes/shaders.$name.tsx
+++ b/apps/web/src/routes/shaders.$name.tsx
@@ -93,14 +93,29 @@ function ShaderDetailPage() {
 
             {/* Preview + Controls */}
             <div class="mb-6 grid gap-4 lg:grid-cols-[1fr_320px]">
-              <ShaderPreviewCanvas
-                vertexSource={s().vertexSource}
-                fragmentSource={s().fragmentSource}
-                uniforms={s().uniforms}
-                uniformOverrides={uniformOverrides()}
-                pipeline={s().pipeline}
-                fallbackSvg={s().previewSvg}
-              />
+              {s().language === 'tsl' ? (
+                <div class="flex aspect-square w-full items-center justify-center overflow-hidden rounded-2xl border border-surface-card-border bg-surface-primary">
+                  {s().previewSvg ? (
+                    <div class="h-full w-full" innerHTML={s().previewSvg!} />
+                  ) : (
+                    <div class="text-center">
+                      <p class="text-sm font-medium text-text-secondary">TSL Shader</p>
+                      <p class="mt-1 text-xs text-text-muted">
+                        WebGPU-based preview coming soon.
+                      </p>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <ShaderPreviewCanvas
+                  vertexSource={s().language === 'glsl' ? s().vertexSource : ''}
+                  fragmentSource={s().language === 'glsl' ? s().fragmentSource : ''}
+                  uniforms={s().uniforms}
+                  uniformOverrides={uniformOverrides()}
+                  pipeline={s().pipeline}
+                  fallbackSvg={s().previewSvg}
+                />
+              )}
               <SurfaceCard class="max-h-[500px] overflow-y-auto p-5">
                 <UniformControls
                   uniforms={s().uniforms}
@@ -238,8 +253,14 @@ function ShaderDetailPage() {
               <h2 class="text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-accent">
                 Shader Source
               </h2>
-              <CodeBlock code={s().vertexSource} language="GLSL (vertex)" />
-              <CodeBlock code={s().fragmentSource} language="GLSL (fragment)" />
+              {s().language === 'tsl' ? (
+                <CodeBlock code={s().tslSource} language="TSL (source.ts)" />
+              ) : (
+                <>
+                  <CodeBlock code={s().vertexSource} language="GLSL (vertex)" />
+                  <CodeBlock code={s().fragmentSource} language="GLSL (fragment)" />
+                </>
+              )}
             </div>
 
             {/* Provenance */}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check": "bun run test && bun run typecheck && bun run validate:shaders && bun run build:web",
     "dev:web": "cd apps/web && bun run dev",
     "test": "node --experimental-strip-types packages/schema/src/index.test.ts && bun run test:cli && bun run test:mcp && bun run test:registry && bun run test:web",
-    "test:web": "node --experimental-strip-types apps/web/src/lib/server/reviews-db.test.node.ts && node --experimental-strip-types apps/web/src/lib/server/playground-db.test.node.ts",
+    "test:web": "node --experimental-strip-types apps/web/src/lib/server/shaders.test.ts && node --experimental-strip-types apps/web/src/lib/server/reviews-db.test.node.ts && node --experimental-strip-types apps/web/src/lib/server/playground-db.test.node.ts",
     "test:cli": "node --experimental-strip-types packages/cli/src/registry-types.test.ts && node --experimental-strip-types packages/cli/src/commands/search.test.ts && node --experimental-strip-types packages/cli/src/commands/add.test.ts && node --experimental-strip-types packages/cli/src/lib/resolve-source.test.ts && node --experimental-strip-types packages/cli/src/lib/build-manifest.test.ts && node --experimental-strip-types packages/cli/src/lib/github-pr.test.ts && node --experimental-strip-types packages/cli/src/commands/submit.test.ts",
     "test:mcp": "node --experimental-strip-types packages/mcp/src/handlers.test.ts && node --experimental-strip-types packages/mcp/src/index.test.ts",
     "test:registry": "node --experimental-strip-types scripts/build-registry.test.ts",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check": "bun run test && bun run typecheck && bun run validate:shaders && bun run build:web",
     "dev:web": "cd apps/web && bun run dev",
     "test": "node --experimental-strip-types packages/schema/src/index.test.ts && bun run test:cli && bun run test:mcp && bun run test:registry && bun run test:web",
-    "test:web": "node --experimental-strip-types apps/web/src/lib/server/reviews-db.test.node.ts",
+    "test:web": "node --experimental-strip-types apps/web/src/lib/server/reviews-db.test.node.ts && node --experimental-strip-types apps/web/src/lib/server/playground-db.test.node.ts",
     "test:cli": "node --experimental-strip-types packages/cli/src/registry-types.test.ts && node --experimental-strip-types packages/cli/src/commands/search.test.ts && node --experimental-strip-types packages/cli/src/commands/add.test.ts && node --experimental-strip-types packages/cli/src/lib/resolve-source.test.ts && node --experimental-strip-types packages/cli/src/lib/build-manifest.test.ts && node --experimental-strip-types packages/cli/src/lib/github-pr.test.ts && node --experimental-strip-types packages/cli/src/commands/submit.test.ts",
     "test:mcp": "node --experimental-strip-types packages/mcp/src/handlers.test.ts && node --experimental-strip-types packages/mcp/src/index.test.ts",
     "test:registry": "node --experimental-strip-types scripts/build-registry.test.ts",

--- a/packages/cli/src/commands/add.test.ts
+++ b/packages/cli/src/commands/add.test.ts
@@ -34,6 +34,7 @@ function makeMockBundle(): RegistryShaderBundle {
     renderers: ["webgl2"],
     sourceKind: "original",
     uniforms: [{ name: "uColor", type: "vec3" }],
+    language: "glsl",
     description: "A radial gradient shader that renders a smooth circular gradient.",
     author: { name: "ShaderBase" },
     license: "MIT",

--- a/packages/cli/src/commands/add.test.ts
+++ b/packages/cli/src/commands/add.test.ts
@@ -165,6 +165,79 @@ runTest("writes all recipes when no environment specified", () => {
   }
 });
 
+runTest("writes TSL shader with recipe in subdirectory using relPath", () => {
+  const tmpDir = mkdtempSync(join(tmpdir(), "shaderbase-test-"));
+  try {
+    const tslBundle: RegistryShaderBundle = {
+      name: "tsl-gradient-wave",
+      displayName: "TSL Gradient Wave",
+      version: "1.0.0",
+      summary: "Animated gradient wave using NodeMaterial",
+      tags: ["tsl", "gradient"],
+      category: "color",
+      pipeline: "surface",
+      stage: "fragment",
+      environments: ["three"],
+      renderers: ["webgpu"],
+      sourceKind: "original",
+      uniforms: [],
+      language: "tsl",
+      description: "A TSL shader.",
+      author: { name: "ShaderBase" },
+      license: "MIT",
+      compatibility: {
+        three: ">=0.170.0",
+        renderers: ["webgpu"],
+        material: "node-material",
+        environments: ["three"],
+      },
+      capabilityProfile: {
+        pipeline: "surface",
+        stage: "fragment",
+        requires: [],
+        outputs: ["color"],
+      },
+      uniformsFull: [],
+      inputs: [],
+      outputs: [{ name: "color", kind: "color", description: "Output color" }],
+      tslSource: "export function createMaterial() { /* TSL */ }",
+      recipes: {
+        three: {
+          exportName: "createTslGradientWaveMaterial",
+          summary: "Creates a TSL gradient wave material",
+          code: "import { createMaterial } from '../source';\nexport function createTslGradientWaveMaterial() { return createMaterial(); }",
+          placeholders: [],
+          requirements: ["three-scene", "webgpu-renderer"],
+          relPath: "recipes/three.ts",
+        },
+      },
+      provenance: {
+        sourceKind: "original",
+        sources: [],
+        attribution: { summary: "Original shader by ShaderBase contributors." },
+      },
+    };
+
+    const paths = writeShaderFiles(tslBundle, { targetDir: tmpDir, environment: "three" });
+
+    const shaderDir = join(tmpDir, "tsl-gradient-wave");
+    // Source file at root
+    assert.ok(existsSync(join(shaderDir, "source.ts")));
+    // Recipe in subdirectory — preserving import paths
+    assert.ok(existsSync(join(shaderDir, "recipes", "three.ts")));
+    // Recipe should NOT be at root
+    assert.ok(!existsSync(join(shaderDir, "three.ts")));
+
+    // Verify the import path works (../source resolves from recipes/)
+    const recipeCode = readFileSync(join(shaderDir, "recipes", "three.ts"), "utf-8");
+    assert.ok(recipeCode.includes("from '../source'"));
+
+    assert.equal(paths.length, 2); // source.ts + recipes/three.ts
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 runTest("throws if shader directory already exists", () => {
   const tmpDir = mkdtempSync(join(tmpdir(), "shaderbase-test-"));
   try {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -38,14 +38,20 @@ export function writeShaderFiles(
 
   const writtenPaths: string[] = [];
 
-  // Write GLSL sources
-  const vertexPath = join(shaderDir, "vertex.glsl");
-  writeFileSync(vertexPath, bundle.vertexSource, "utf-8");
-  writtenPaths.push(vertexPath);
+  // Write source files based on language
+  if (bundle.language === "tsl") {
+    const tslPath = join(shaderDir, "source.ts");
+    writeFileSync(tslPath, bundle.tslSource, "utf-8");
+    writtenPaths.push(tslPath);
+  } else {
+    const vertexPath = join(shaderDir, "vertex.glsl");
+    writeFileSync(vertexPath, bundle.vertexSource, "utf-8");
+    writtenPaths.push(vertexPath);
 
-  const fragmentPath = join(shaderDir, "fragment.glsl");
-  writeFileSync(fragmentPath, bundle.fragmentSource, "utf-8");
-  writtenPaths.push(fragmentPath);
+    const fragmentPath = join(shaderDir, "fragment.glsl");
+    writeFileSync(fragmentPath, bundle.fragmentSource, "utf-8");
+    writtenPaths.push(fragmentPath);
+  }
 
   // Determine which recipes to write
   const recipeKeys = options.environment

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, writeFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type { RegistryShaderBundle } from "../registry-types.ts";
 
 // ---------------------------------------------------------------------------
@@ -12,7 +12,7 @@ export type WriteOptions = {
 };
 
 // ---------------------------------------------------------------------------
-// Recipe target → file name mapping
+// Fallback recipe file names (used when relPath is not in the bundle)
 // ---------------------------------------------------------------------------
 
 const RECIPE_FILE_NAMES: Record<string, string> = {
@@ -62,10 +62,13 @@ export function writeShaderFiles(
     const recipe = bundle.recipes[key];
     if (!recipe) continue;
 
-    const fileName = RECIPE_FILE_NAMES[key];
-    if (!fileName) continue;
+    // Use relPath from bundle if available, otherwise fall back to flat filename
+    const relFile = recipe.relPath ?? RECIPE_FILE_NAMES[key];
+    if (!relFile) continue;
 
-    const recipePath = join(shaderDir, fileName);
+    const recipePath = join(shaderDir, relFile);
+    // Ensure subdirectories exist (e.g. recipes/)
+    mkdirSync(dirname(recipePath), { recursive: true });
     writeFileSync(recipePath, recipe.code, "utf-8");
     writtenPaths.push(recipePath);
   }

--- a/packages/cli/src/commands/search.test.ts
+++ b/packages/cli/src/commands/search.test.ts
@@ -18,7 +18,7 @@ function runTest(name: string, callback: () => void) {
 
 function makeMockIndex(): RegistryIndex {
   return {
-    version: "0.1.0",
+    version: "0.2.0",
     generatedAt: "2026-03-07T00:00:00Z",
     shaders: [
       {
@@ -34,6 +34,7 @@ function makeMockIndex(): RegistryIndex {
         renderers: ["webgl2"],
         sourceKind: "original",
         uniforms: [{ name: "uColor", type: "vec3" }],
+        language: "glsl",
       },
       {
         name: "vignette-postprocess",
@@ -48,6 +49,7 @@ function makeMockIndex(): RegistryIndex {
         renderers: ["webgl2"],
         sourceKind: "original",
         uniforms: [{ name: "uIntensity", type: "float" }],
+        language: "glsl",
       },
       {
         name: "simplex-displacement",
@@ -62,6 +64,7 @@ function makeMockIndex(): RegistryIndex {
         renderers: ["webgl2"],
         sourceKind: "adapted",
         uniforms: [{ name: "uAmplitude", type: "float" }],
+        language: "glsl",
       },
     ],
   };

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -10,6 +10,7 @@ export type SearchFilters = {
   pipeline?: string;
   environment?: string;
   tags?: string[];
+  language?: string;
 };
 
 // ---------------------------------------------------------------------------
@@ -33,7 +34,7 @@ export function searchShaders(
   index: RegistryIndex,
   filters: SearchFilters,
 ): RegistryIndexEntry[] {
-  const { query, category, pipeline, environment, tags } = filters;
+  const { query, category, pipeline, environment, tags, language } = filters;
 
   return index.shaders.filter((shader) => {
     // query — case-insensitive match against name, displayName, summary, or any tag
@@ -45,6 +46,11 @@ export function searchShaders(
         shader.summary.toLowerCase().includes(q) ||
         shader.tags.some((t) => t.toLowerCase().includes(q));
       if (!matchesQuery) return false;
+    }
+
+    // language — exact case-insensitive match
+    if (language) {
+      if ((shader.language ?? "glsl").toLowerCase() !== language.toLowerCase()) return false;
     }
 
     // category — exact case-insensitive match

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,7 +5,7 @@ export type { WriteOptions } from "./commands/add.ts";
 export { runSubmit } from "./commands/submit.ts";
 export type { SubmitInput, SubmitResult } from "./commands/submit.ts";
 export { fetchIndex, fetchShaderBundle, getRegistryUrl } from "./lib/registry-client.ts";
-export type { RegistryIndex, RegistryIndexEntry, RegistryShaderBundle } from "./registry-types.ts";
+export type { RegistryIndex, RegistryIndexEntry, RegistryShaderBundle, RegistryGlslBundle, RegistryTslBundle } from "./registry-types.ts";
 export { resolveSource } from "./lib/resolve-source.ts";
 export type { ResolvedSource } from "./lib/resolve-source.ts";
 export { aiParseShader } from "./lib/ai-parse.ts";

--- a/packages/cli/src/registry-types.test.ts
+++ b/packages/cli/src/registry-types.test.ts
@@ -35,12 +35,14 @@ function makeValidIndexEntry() {
       { name: "uColor", type: "vec3" },
       { name: "uRadius", type: "float" },
     ],
+    language: "glsl",
   };
 }
 
 function makeValidShaderBundle() {
   return {
     ...makeValidIndexEntry(),
+    language: "glsl" as const,
     description: "A radial gradient shader that renders a smooth circular gradient.",
     author: { name: "ShaderBase" },
     license: "MIT",
@@ -107,6 +109,59 @@ function makeValidShaderBundle() {
   };
 }
 
+function makeValidTslBundle() {
+  return {
+    ...makeValidIndexEntry(),
+    language: "tsl" as const,
+    description: "A TSL noise shader that generates procedural noise.",
+    author: { name: "ShaderBase" },
+    license: "MIT",
+    compatibility: {
+      three: ">=0.160.0",
+      renderers: ["webgpu"],
+      material: "shader-material",
+      environments: ["three"],
+    },
+    capabilityProfile: {
+      pipeline: "surface",
+      stage: "fragment",
+      requires: ["uv"],
+      outputs: ["color"],
+    },
+    uniformsFull: [
+      {
+        name: "uScale",
+        type: "float",
+        defaultValue: 1.0,
+        description: "Noise scale",
+      },
+    ],
+    inputs: [
+      { name: "uv", kind: "uv", description: "UV coordinates", required: true },
+    ],
+    outputs: [
+      { name: "fragColor", kind: "color", description: "Output fragment color" },
+    ],
+    tslSource: "import { uniform, uv, vec4 } from 'three/tsl';\nexport const noiseMaterial = () => vec4(uv(), 0.0, 1.0);",
+    recipes: {
+      three: {
+        exportName: "createNoiseMaterial",
+        summary: "Creates a TSL noise material",
+        code: "import { noiseMaterial } from './noise.tsl.ts';\nexport function createNoiseMaterial() { return noiseMaterial(); }",
+        placeholders: [],
+        requirements: ["three-scene", "mesh"],
+      },
+    },
+    provenance: {
+      sourceKind: "original",
+      sources: [],
+      attribution: {
+        summary: "Original shader by ShaderBase contributors.",
+      },
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -134,8 +189,11 @@ runTest("validates a valid shader bundle", () => {
   const result = registryShaderBundleSchema.parse(bundle);
 
   assert.equal(result.name, "gradient-radial");
-  assert.equal(result.vertexSource.length > 0, true);
-  assert.equal(result.fragmentSource.length > 0, true);
+  assert.equal(result.language, "glsl");
+  if (result.language === "glsl") {
+    assert.equal(result.vertexSource.length > 0, true);
+    assert.equal(result.fragmentSource.length > 0, true);
+  }
   assert.equal(Object.keys(result.recipes).length, 1);
   assert.equal(result.provenance.sourceKind, "original");
 });
@@ -144,6 +202,27 @@ runTest("rejects bundle without vertexSource", () => {
   const bundle = makeValidShaderBundle();
   const { vertexSource: _, ...withoutVertex } = bundle;
   const result = registryShaderBundleSchema.safeParse(withoutVertex);
+
+  assert.equal(result.success, false);
+});
+
+runTest("validates a valid TSL shader bundle", () => {
+  const bundle = makeValidTslBundle();
+  const result = registryShaderBundleSchema.parse(bundle);
+
+  assert.equal(result.name, "gradient-radial");
+  assert.equal(result.language, "tsl");
+  if (result.language === "tsl") {
+    assert.equal(result.tslSource.length > 0, true);
+  }
+  assert.equal(Object.keys(result.recipes).length, 1);
+  assert.equal(result.provenance.sourceKind, "original");
+});
+
+runTest("rejects TSL bundle without tslSource", () => {
+  const bundle = makeValidTslBundle();
+  const { tslSource: _, ...withoutTsl } = bundle;
+  const result = registryShaderBundleSchema.safeParse(withoutTsl);
 
   assert.equal(result.success, false);
 });

--- a/packages/cli/src/registry-types.ts
+++ b/packages/cli/src/registry-types.ts
@@ -80,6 +80,7 @@ export const registryRecipeBundleSchema = z.object({
   code: z.string().min(1),
   placeholders: z.array(registryRecipePlaceholderSchema),
   requirements: z.array(z.string().min(1)),
+  relPath: z.string().min(1).optional(),
 });
 
 export type RegistryRecipeBundle = z.infer<typeof registryRecipeBundleSchema>;

--- a/packages/cli/src/registry-types.ts
+++ b/packages/cli/src/registry-types.ts
@@ -28,6 +28,7 @@ export const registryIndexEntrySchema = z.object({
   renderers: z.array(z.string().min(1)).min(1),
   sourceKind: z.string().min(1),
   uniforms: z.array(registryUniformSummarySchema),
+  language: z.string().min(1),
 });
 
 export type RegistryIndexEntry = z.infer<typeof registryIndexEntrySchema>;
@@ -37,7 +38,7 @@ export type RegistryIndexEntry = z.infer<typeof registryIndexEntrySchema>;
 // ---------------------------------------------------------------------------
 
 export const registryIndexSchema = z.object({
-  version: z.literal("0.1.0"),
+  version: z.literal("0.2.0"),
   generatedAt: z.string().min(1),
   shaders: z.array(registryIndexEntrySchema),
 });
@@ -165,8 +166,8 @@ export type RegistryCompatibility = z.infer<typeof registryCompatibilitySchema>;
 // Shader bundle — full detail for a single shader (served by MCP / CLI add)
 // ---------------------------------------------------------------------------
 
-export const registryShaderBundleSchema = z.object({
-  // Fields from the index entry
+// Base fields shared by all bundles
+const registryShaderBundleBaseFields = {
   name: z.string().min(1),
   displayName: z.string().min(1),
   version: z.string().min(1),
@@ -179,6 +180,7 @@ export const registryShaderBundleSchema = z.object({
   renderers: z.array(z.string().min(1)).min(1),
   sourceKind: z.string().min(1),
   uniforms: z.array(registryUniformSummarySchema),
+  language: z.string().min(1),
 
   // Extended fields
   description: z.string().min(1),
@@ -193,10 +195,28 @@ export const registryShaderBundleSchema = z.object({
   uniformsFull: z.array(registryUniformFullSchema),
   inputs: z.array(registryInputSchema),
   outputs: z.array(registryOutputSchema),
-  vertexSource: z.string().min(1),
-  fragmentSource: z.string().min(1),
   recipes: z.record(z.string(), registryRecipeBundleSchema),
   provenance: registryProvenanceSchema,
+};
+
+const registryGlslBundleSchema = z.object({
+  ...registryShaderBundleBaseFields,
+  language: z.literal("glsl"),
+  vertexSource: z.string().min(1),
+  fragmentSource: z.string().min(1),
 });
 
+const registryTslBundleSchema = z.object({
+  ...registryShaderBundleBaseFields,
+  language: z.literal("tsl"),
+  tslSource: z.string().min(1),
+});
+
+export const registryShaderBundleSchema = z.discriminatedUnion("language", [
+  registryGlslBundleSchema,
+  registryTslBundleSchema,
+]);
+
+export type RegistryGlslBundle = z.infer<typeof registryGlslBundleSchema>;
+export type RegistryTslBundle = z.infer<typeof registryTslBundleSchema>;
 export type RegistryShaderBundle = z.infer<typeof registryShaderBundleSchema>;

--- a/packages/mcp/src/handlers.test.ts
+++ b/packages/mcp/src/handlers.test.ts
@@ -22,7 +22,7 @@ function runTest(name: string, callback: () => void | Promise<void>) {
 // ---------------------------------------------------------------------------
 
 const mockIndex: RegistryIndex = {
-  version: "0.1.0",
+  version: "0.2.0",
   generatedAt: "2026-03-07T00:00:00Z",
   shaders: [
     {
@@ -38,6 +38,7 @@ const mockIndex: RegistryIndex = {
       renderers: ["webgl2"],
       sourceKind: "original",
       uniforms: [{ name: "uColor", type: "vec3" }],
+      language: "glsl",
     },
     {
       name: "vignette-postprocess",
@@ -52,6 +53,7 @@ const mockIndex: RegistryIndex = {
       renderers: ["webgl2"],
       sourceKind: "original",
       uniforms: [{ name: "uIntensity", type: "float" }],
+      language: "glsl",
     },
   ],
 };
@@ -69,6 +71,7 @@ const mockBundle: RegistryShaderBundle = {
   renderers: ["webgl2"],
   sourceKind: "original",
   uniforms: [{ name: "uColor", type: "vec3" }],
+  language: "glsl",
   description: "Renders a smooth radial gradient between two colors.",
   author: { name: "ShaderBase" },
   license: "MIT",
@@ -185,7 +188,10 @@ async function main() {
       mockFetch,
     );
     assert.equal(bundle.name, "gradient-radial");
-    assert.ok(bundle.vertexSource.length > 0);
+    assert.equal(bundle.language, "glsl");
+    if (bundle.language === "glsl") {
+      assert.ok(bundle.vertexSource.length > 0);
+    }
     assert.ok(Object.keys(bundle.recipes).length === 2);
     assert.ok("three" in bundle.recipes);
     assert.ok("r3f" in bundle.recipes);

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -20,6 +20,7 @@ export async function handleSearchShaders(
     pipeline?: string;
     environment?: string;
     tags?: string[];
+    language?: string;
   },
   registryUrl: string,
   fetchFn: (input: string | URL | Request) => Promise<Response> = fetch,

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -79,6 +79,10 @@ const TOOLS = [
           items: { type: "string" },
           description: "Filter by tags — all specified tags must be present.",
         },
+        language: {
+          type: "string",
+          description: "Filter by shader language ('glsl' or 'tsl').",
+        },
       },
       additionalProperties: false,
     },
@@ -130,6 +134,14 @@ const TOOLS = [
       properties: {
         vertexSource: { type: "string", description: "Initial vertex shader GLSL source." },
         fragmentSource: { type: "string", description: "Initial fragment shader GLSL source." },
+        language: {
+          type: "string",
+          description: "Shader language: 'glsl' (default) or 'tsl'.",
+        },
+        tslSource: {
+          type: "string",
+          description: "TSL source code (when language is 'tsl').",
+        },
         uniforms: {
           type: "array",
           items: {
@@ -161,6 +173,10 @@ const TOOLS = [
         sessionId: { type: "string", description: "The playground session ID." },
         vertexSource: { type: "string", description: "New vertex shader GLSL source." },
         fragmentSource: { type: "string", description: "New fragment shader GLSL source." },
+        tslSource: {
+          type: "string",
+          description: "New TSL source code (for TSL sessions).",
+        },
       },
       required: ["sessionId"],
       additionalProperties: false,
@@ -227,6 +243,10 @@ const TOOLS_MCP_FORMAT = [
           items: { type: "string" },
           description: "Filter by tags (all must match)",
         },
+        language: {
+          type: "string",
+          description: "Filter by shader language ('glsl' or 'tsl').",
+        },
       },
     },
   },
@@ -279,6 +299,14 @@ const TOOLS_MCP_FORMAT = [
           type: "string",
           description: "Initial fragment shader GLSL source (defaults to an animated color gradient)",
         },
+        language: {
+          type: "string",
+          description: "Shader language: 'glsl' (default) or 'tsl'.",
+        },
+        tslSource: {
+          type: "string",
+          description: "TSL source code (when language is 'tsl').",
+        },
         uniforms: {
           type: "array",
           items: {
@@ -320,6 +348,10 @@ const TOOLS_MCP_FORMAT = [
         fragmentSource: {
           type: "string",
           description: "New fragment shader GLSL source",
+        },
+        tslSource: {
+          type: "string",
+          description: "New TSL source code (for TSL sessions).",
         },
       },
       required: ["sessionId"] as const,
@@ -412,6 +444,7 @@ async function handleMcpToolCall(
         pipeline?: string;
         environment?: string;
         tags?: string[];
+        language?: string;
       },
       registryUrl,
     );
@@ -466,6 +499,8 @@ async function handleMcpToolCall(
       toolArgs as {
         vertexSource?: string;
         fragmentSource?: string;
+        tslSource?: string;
+        language?: string;
         pipeline?: string;
       },
       playgroundEnv,
@@ -480,7 +515,7 @@ async function handleMcpToolCall(
       throw new Error("Missing required parameter: sessionId");
     }
     const result = await handleUpdateShader(
-      toolArgs as { sessionId: string; vertexSource?: string; fragmentSource?: string },
+      toolArgs as { sessionId: string; vertexSource?: string; fragmentSource?: string; tslSource?: string },
       playgroundEnv,
     );
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -128,7 +128,7 @@ const TOOLS = [
   {
     name: "create_playground",
     description:
-      "Create a new shader playground session for live GLSL editing with visual preview.",
+      "Create a new shader playground session. GLSL sessions have visual preview; TSL sessions support editing only (previewAvailable flag indicates status).",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -166,7 +166,7 @@ const TOOLS = [
   {
     name: "update_shader",
     description:
-      "Update GLSL source in a playground session. Returns compilation errors and a screenshot.",
+      "Update shader source in a playground session. Returns compilation errors, structured errors, and a screenshot (GLSL only).",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -198,7 +198,7 @@ const TOOLS = [
   {
     name: "get_errors",
     description:
-      "Get compilation errors from a playground session.",
+      "Get compilation errors and structured errors from a playground session.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -287,7 +287,7 @@ const TOOLS_MCP_FORMAT = [
   {
     name: "create_playground",
     description:
-      "Create a new shader playground session for live GLSL editing with visual preview. Returns a session ID and URL to open in a browser. An AI agent can then use update_shader to change the GLSL and get_preview to see screenshots of the result.",
+      "Create a new shader playground session for live editing. Supports both GLSL and TSL languages. GLSL sessions have full visual preview with screenshots. TSL sessions support source editing but preview is not yet available (previewAvailable will be false). Returns a session ID, URL, and previewAvailable flag.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -333,7 +333,7 @@ const TOOLS_MCP_FORMAT = [
   {
     name: "update_shader",
     description:
-      "Update GLSL source in a playground session. Pushes changes to any connected browser for live preview. Waits up to 5 seconds for a screenshot from the browser. Returns compilation errors (if any) and a screenshot of the rendered result.",
+      "Update shader source in a playground session. For GLSL sessions, provide vertexSource/fragmentSource. For TSL sessions, provide tslSource. Returns compilation errors, structured errors (with kind and message), and a screenshot for GLSL sessions. The previewAvailable flag indicates whether screenshots are supported.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -343,15 +343,15 @@ const TOOLS_MCP_FORMAT = [
         },
         vertexSource: {
           type: "string",
-          description: "New vertex shader GLSL source",
+          description: "New vertex shader GLSL source (GLSL sessions only)",
         },
         fragmentSource: {
           type: "string",
-          description: "New fragment shader GLSL source",
+          description: "New fragment shader GLSL source (GLSL sessions only)",
         },
         tslSource: {
           type: "string",
-          description: "New TSL source code (for TSL sessions).",
+          description: "New TSL source code (TSL sessions only)",
         },
       },
       required: ["sessionId"] as const,
@@ -360,7 +360,7 @@ const TOOLS_MCP_FORMAT = [
   {
     name: "get_preview",
     description:
-      "Get the latest screenshot from a playground session. Returns the most recent rendered frame as a PNG image.",
+      "Get the latest screenshot from a playground session. Only available for GLSL sessions (TSL preview not yet implemented). Returns the most recent rendered frame as a PNG image.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -375,7 +375,7 @@ const TOOLS_MCP_FORMAT = [
   {
     name: "get_errors",
     description:
-      "Get compilation errors from a playground session. Returns an array of GLSL compilation error strings with line numbers.",
+      "Get compilation errors from a playground session. Returns plain error strings and structured errors (with kind like 'glsl-compile', 'tsl-parse', 'tsl-runtime', 'tsl-material-build' and message).",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -526,7 +526,9 @@ async function handleMcpToolCall(
       type: "text",
       text: JSON.stringify({
         compilationErrors: result.compilationErrors,
+        structuredErrors: result.structuredErrors,
         browserConnected: result.browserConnected,
+        previewAvailable: result.previewAvailable,
       }, null, 2),
     });
 
@@ -557,6 +559,11 @@ async function handleMcpToolCall(
       const base64Data = result.screenshotBase64.replace(/^data:image\/png;base64,/, "");
       return {
         content: [{ type: "image", data: base64Data, mimeType: "image/png" }],
+      };
+    }
+    if (result.language === "tsl") {
+      return {
+        content: [{ type: "text", text: "Preview not available for TSL sessions. TSL preview requires WebGPU which is not yet implemented." }],
       };
     }
     return {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -81,6 +81,7 @@ const TOOLS = [
         },
         language: {
           type: "string",
+          enum: ["glsl", "tsl"],
           description: "Filter by shader language ('glsl' or 'tsl').",
         },
       },
@@ -136,6 +137,7 @@ const TOOLS = [
         fragmentSource: { type: "string", description: "Initial fragment shader GLSL source." },
         language: {
           type: "string",
+          enum: ["glsl", "tsl"],
           description: "Shader language: 'glsl' (default) or 'tsl'.",
         },
         tslSource: {
@@ -245,6 +247,7 @@ const TOOLS_MCP_FORMAT = [
         },
         language: {
           type: "string",
+          enum: ["glsl", "tsl"],
           description: "Filter by shader language ('glsl' or 'tsl').",
         },
       },
@@ -301,6 +304,7 @@ const TOOLS_MCP_FORMAT = [
         },
         language: {
           type: "string",
+          enum: ["glsl", "tsl"],
           description: "Shader language: 'glsl' (default) or 'tsl'.",
         },
         tslSource: {

--- a/packages/mcp/src/playground-handlers.test.ts
+++ b/packages/mcp/src/playground-handlers.test.ts
@@ -60,20 +60,53 @@ async function main() {
     const mockFetch = createMockFetch({
       "/api/playground/create": {
         status: 200,
-        body: { sessionId: "abc-123", url: "https://test.shaderbase.com/playground?session=abc-123" },
+        body: {
+          sessionId: "abc-123",
+          url: "https://test.shaderbase.com/playground?session=abc-123",
+          previewAvailable: true,
+        },
       },
     });
 
     const result = await handleCreatePlayground({}, env, mockFetch);
     assert.equal(result.sessionId, "abc-123");
     assert.ok(result.url.includes("abc-123"));
+    assert.equal(result.previewAvailable, true);
+  });
+
+  await runTest("create_playground returns previewAvailable flag", async () => {
+    const mockFetch = createMockFetch({
+      "/api/playground/create": {
+        status: 200,
+        body: { sessionId: "glsl-1", url: "https://test.shaderbase.com/playground?session=glsl-1", previewAvailable: true },
+      },
+    });
+
+    const result = await handleCreatePlayground({}, env, mockFetch);
+    assert.equal(result.previewAvailable, true);
+  });
+
+  await runTest("create_playground TSL session returns previewAvailable false", async () => {
+    const mockFetch = createMockFetch({
+      "/api/playground/create": {
+        status: 200,
+        body: { sessionId: "tsl-1", url: "https://test.shaderbase.com/playground?session=tsl-1", previewAvailable: false },
+      },
+    });
+
+    const result = await handleCreatePlayground({ language: "tsl", tslSource: "// tsl" }, env, mockFetch);
+    assert.equal(result.previewAvailable, false);
   });
 
   await runTest("create_playground forwards custom GLSL", async () => {
     let capturedBody: string | undefined;
     const mockFetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
       capturedBody = init?.body as string;
-      return new Response(JSON.stringify({ sessionId: "xyz", url: "http://test/playground?session=xyz" }), {
+      return new Response(JSON.stringify({
+        sessionId: "xyz",
+        url: "http://test/playground?session=xyz",
+        previewAvailable: true,
+      }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
@@ -97,8 +130,10 @@ async function main() {
         status: 200,
         body: {
           compilationErrors: [],
+          structuredErrors: [],
           screenshotBase64: "data:image/png;base64,abc",
           browserConnected: true,
+          previewAvailable: true,
         },
       },
     });
@@ -109,8 +144,35 @@ async function main() {
       mockFetch,
     );
     assert.deepEqual(result.compilationErrors, []);
+    assert.deepEqual(result.structuredErrors, []);
     assert.equal(result.screenshotBase64, "data:image/png;base64,abc");
     assert.equal(result.browserConnected, true);
+    assert.equal(result.previewAvailable, true);
+  });
+
+  await runTest("update_shader returns structured errors and previewAvailable", async () => {
+    const mockFetch = createMockFetch({
+      "/api/playground/tsl-sess/update": {
+        status: 200,
+        body: {
+          compilationErrors: [],
+          structuredErrors: [{ kind: "tsl-parse", message: "Unexpected token at line 3" }],
+          screenshotBase64: null,
+          browserConnected: false,
+          previewAvailable: false,
+        },
+      },
+    });
+
+    const result = await handleUpdateShader(
+      { sessionId: "tsl-sess", tslSource: "bad code" },
+      env,
+      mockFetch,
+    );
+    assert.equal(result.structuredErrors.length, 1);
+    assert.equal(result.structuredErrors[0]!.kind, "tsl-parse");
+    assert.equal(result.previewAvailable, false);
+    assert.equal(result.screenshotBase64, null);
   });
 
   await runTest("update_shader throws on failure", async () => {
@@ -127,53 +189,74 @@ async function main() {
     );
   });
 
-  await runTest("get_preview returns screenshot", async () => {
+  await runTest("get_preview returns screenshot and language", async () => {
     const mockFetch = createMockFetch({
       "/api/playground/sess-2/state": {
         status: 200,
-        body: { screenshotBase64: "data:image/png;base64,screenshot" },
+        body: { screenshotBase64: "data:image/png;base64,screenshot", language: "glsl" },
       },
     });
 
     const result = await handleGetPreview({ sessionId: "sess-2" }, env, mockFetch);
     assert.equal(result.screenshotBase64, "data:image/png;base64,screenshot");
+    assert.equal(result.language, "glsl");
   });
 
-  await runTest("get_preview returns null when no screenshot", async () => {
+  await runTest("get_preview returns null screenshot for GLSL session", async () => {
     const mockFetch = createMockFetch({
       "/api/playground/sess-3/state": {
         status: 200,
-        body: { screenshotBase64: null },
+        body: { screenshotBase64: null, language: "glsl" },
       },
     });
 
     const result = await handleGetPreview({ sessionId: "sess-3" }, env, mockFetch);
     assert.equal(result.screenshotBase64, null);
+    assert.equal(result.language, "glsl");
   });
 
-  await runTest("get_errors returns error list", async () => {
+  await runTest("get_preview returns language tsl for TSL sessions", async () => {
+    const mockFetch = createMockFetch({
+      "/api/playground/tsl-prev/state": {
+        status: 200,
+        body: { screenshotBase64: null, language: "tsl" },
+      },
+    });
+
+    const result = await handleGetPreview({ sessionId: "tsl-prev" }, env, mockFetch);
+    assert.equal(result.screenshotBase64, null);
+    assert.equal(result.language, "tsl");
+  });
+
+  await runTest("get_errors returns error list with structured errors", async () => {
     const mockFetch = createMockFetch({
       "/api/playground/sess-4/errors": {
         status: 200,
-        body: { errors: ["ERROR: 0:5: undeclared identifier"] },
+        body: {
+          errors: ["ERROR: 0:5: undeclared identifier"],
+          structuredErrors: [{ kind: "glsl-compile", message: "ERROR: 0:5: undeclared identifier" }],
+        },
       },
     });
 
     const result = await handleGetErrors({ sessionId: "sess-4" }, env, mockFetch);
     assert.equal(result.errors.length, 1);
     assert.ok(result.errors[0]!.includes("undeclared"));
+    assert.equal(result.structuredErrors.length, 1);
+    assert.equal(result.structuredErrors[0]!.kind, "glsl-compile");
   });
 
-  await runTest("get_errors returns empty array when no errors", async () => {
+  await runTest("get_errors returns empty arrays when no errors", async () => {
     const mockFetch = createMockFetch({
       "/api/playground/sess-5/errors": {
         status: 200,
-        body: { errors: [] },
+        body: { errors: [], structuredErrors: [] },
       },
     });
 
     const result = await handleGetErrors({ sessionId: "sess-5" }, env, mockFetch);
     assert.deepEqual(result.errors, []);
+    assert.deepEqual(result.structuredErrors, []);
   });
 
   console.log("playground-handlers tests passed");

--- a/packages/mcp/src/playground-handlers.ts
+++ b/packages/mcp/src/playground-handlers.ts
@@ -22,6 +22,8 @@ export async function handleCreatePlayground(
   args: {
     vertexSource?: string;
     fragmentSource?: string;
+    tslSource?: string;
+    language?: string;
     uniforms?: Array<{ name: string; type: string; defaultValue: unknown }>;
     pipeline?: string;
   },
@@ -51,6 +53,7 @@ export async function handleUpdateShader(
     sessionId: string;
     vertexSource?: string;
     fragmentSource?: string;
+    tslSource?: string;
   },
   env: PlaygroundEnv,
   fetchFn: (input: string | URL | Request, init?: RequestInit) => Promise<Response> = fetch,

--- a/packages/mcp/src/playground-handlers.ts
+++ b/packages/mcp/src/playground-handlers.ts
@@ -29,7 +29,7 @@ export async function handleCreatePlayground(
   },
   env: PlaygroundEnv,
   fetchFn: (input: string | URL | Request, init?: RequestInit) => Promise<Response> = fetch,
-): Promise<{ sessionId: string; url: string }> {
+): Promise<{ sessionId: string; url: string; previewAvailable: boolean }> {
   const response = await fetchFn(`${env.webAppUrl}/api/playground/create`, {
     method: "POST",
     headers: authHeaders(env),
@@ -41,12 +41,14 @@ export async function handleCreatePlayground(
     throw new Error(`Failed to create playground session: ${response.status} ${body}`);
   }
 
-  return (await response.json()) as { sessionId: string; url: string };
+  return (await response.json()) as { sessionId: string; url: string; previewAvailable: boolean };
 }
 
 // ---------------------------------------------------------------------------
 // update_shader
 // ---------------------------------------------------------------------------
+
+export type StructuredError = { kind: string; message: string };
 
 export async function handleUpdateShader(
   args: {
@@ -59,8 +61,10 @@ export async function handleUpdateShader(
   fetchFn: (input: string | URL | Request, init?: RequestInit) => Promise<Response> = fetch,
 ): Promise<{
   compilationErrors: string[];
+  structuredErrors: StructuredError[];
   screenshotBase64: string | null;
   browserConnected: boolean;
+  previewAvailable: boolean;
 }> {
   const { sessionId, ...shaderUpdate } = args;
   const response = await fetchFn(`${env.webAppUrl}/api/playground/${sessionId}/update`, {
@@ -76,8 +80,10 @@ export async function handleUpdateShader(
 
   return (await response.json()) as {
     compilationErrors: string[];
+    structuredErrors: StructuredError[];
     screenshotBase64: string | null;
     browserConnected: boolean;
+    previewAvailable: boolean;
   };
 }
 
@@ -89,7 +95,7 @@ export async function handleGetPreview(
   args: { sessionId: string },
   env: PlaygroundEnv,
   fetchFn: (input: string | URL | Request, init?: RequestInit) => Promise<Response> = fetch,
-): Promise<{ screenshotBase64: string | null }> {
+): Promise<{ screenshotBase64: string | null; language: string }> {
   const response = await fetchFn(`${env.webAppUrl}/api/playground/${args.sessionId}/state`, {
     method: "GET",
     headers: { Authorization: `Bearer ${env.playgroundSecret}` },
@@ -100,8 +106,8 @@ export async function handleGetPreview(
     throw new Error(`Failed to get preview: ${response.status} ${body}`);
   }
 
-  const session = (await response.json()) as { screenshotBase64: string | null };
-  return { screenshotBase64: session.screenshotBase64 };
+  const session = (await response.json()) as { screenshotBase64: string | null; language: string };
+  return { screenshotBase64: session.screenshotBase64, language: session.language };
 }
 
 // ---------------------------------------------------------------------------
@@ -112,7 +118,7 @@ export async function handleGetErrors(
   args: { sessionId: string },
   env: PlaygroundEnv,
   fetchFn: (input: string | URL | Request, init?: RequestInit) => Promise<Response> = fetch,
-): Promise<{ errors: string[] }> {
+): Promise<{ errors: string[]; structuredErrors: StructuredError[] }> {
   const response = await fetchFn(`${env.webAppUrl}/api/playground/${args.sessionId}/errors`, {
     method: "GET",
     headers: { Authorization: `Bearer ${env.playgroundSecret}` },
@@ -123,5 +129,5 @@ export async function handleGetErrors(
     throw new Error(`Failed to get errors: ${response.status} ${body}`);
   }
 
-  return (await response.json()) as { errors: string[] };
+  return (await response.json()) as { errors: string[]; structuredErrors: StructuredError[] };
 }

--- a/packages/schema/src/index.test.ts
+++ b/packages/schema/src/index.test.ts
@@ -104,4 +104,42 @@ runTest("rejects missing referenced files", () => {
   }
 });
 
+runTest("defaults language to glsl when missing", () => {
+  const manifest = JSON.parse(readFileSync(fixtureManifestPath, "utf8")) as Record<string, unknown>;
+  delete manifest.language;
+
+  const result = shaderManifestSchema.safeParse(manifest);
+  assert.equal(result.success, true);
+  if (result.success) {
+    assert.equal(result.data.language, "glsl");
+  }
+});
+
+runTest("validates a TSL manifest", () => {
+  const manifest = JSON.parse(readFileSync(fixtureManifestPath, "utf8")) as Record<string, unknown>;
+  manifest.language = "tsl";
+  manifest.tslEntry = "source.ts";
+  manifest.compatibility = {
+    ...(manifest.compatibility as Record<string, unknown>),
+    renderers: ["webgpu"],
+    material: "node-material",
+  };
+  delete manifest.files;
+
+  const result = shaderManifestSchema.safeParse(manifest);
+  assert.equal(result.success, true);
+  if (result.success) {
+    assert.equal(result.data.language, "tsl");
+  }
+});
+
+runTest("rejects TSL manifest without tslEntry", () => {
+  const manifest = JSON.parse(readFileSync(fixtureManifestPath, "utf8")) as Record<string, unknown>;
+  manifest.language = "tsl";
+  delete manifest.files;
+
+  const result = shaderManifestSchema.safeParse(manifest);
+  assert.equal(result.success, false);
+});
+
 console.log("schema tests passed");

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -185,6 +185,7 @@ const compatibilitySchema = z.object({
     "shader-material",
     "raw-shader-material",
     "post-processing-pass",
+    "node-material",
     "custom",
   ]),
   environments: z.array(z.enum(["three", "react-three-fiber"])).min(1),
@@ -320,66 +321,120 @@ const provenanceSchema = z
     });
   });
 
-export const shaderManifestSchema = z
-  .object({
-    schemaVersion: z.literal("0.1.0"),
-    name: shaderNameSchema,
-    displayName: nonEmptyStringSchema,
-    version: nonEmptyStringSchema,
-    summary: nonEmptyStringSchema,
-    description: nonEmptyStringSchema,
-    author: authorSchema,
-    license: nonEmptyStringSchema,
-    tags: z.array(nonEmptyStringSchema).min(1),
-    category: nonEmptyStringSchema,
-    capabilityProfile: capabilityProfileSchema,
-    compatibility: compatibilitySchema,
-    uniforms: z.array(uniformSchema),
-    inputs: z.array(inputSchema).default([]),
-    outputs: z.array(outputSchema).min(1),
-    files: fileReferencesSchema,
-    recipes: z.array(recipeSchema).min(1),
-    preview: previewSchema,
-    provenance: provenanceSchema,
-  })
-  .superRefine((manifest, ctx) => {
-    const recipeTargets = new Set<string>();
+// ---------------------------------------------------------------------------
+// Recipe cross-validation (shared by both GLSL and TSL variants)
+// ---------------------------------------------------------------------------
 
-    manifest.recipes.forEach((recipe, index) => {
-      if (recipeTargets.has(recipe.target)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `duplicate recipe target "${recipe.target}"`,
-          path: ["recipes", index, "target"],
-        });
-      }
+type ManifestWithRecipesAndCompat = {
+  recipes: Array<{ target: string }>;
+  compatibility: { environments: string[] };
+};
 
-      recipeTargets.add(recipe.target);
+function validateRecipes(manifest: ManifestWithRecipesAndCompat, ctx: z.RefinementCtx) {
+  const recipeTargets = new Set<string>();
 
-      if (recipe.target === "three" && !manifest.compatibility.environments.includes("three")) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "compatibility.environments must include \"three\" when a Three.js recipe exists",
-          path: ["compatibility", "environments"],
-        });
-      }
+  manifest.recipes.forEach((recipe, index) => {
+    if (recipeTargets.has(recipe.target)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `duplicate recipe target "${recipe.target}"`,
+        path: ["recipes", index, "target"],
+      });
+    }
 
-      if (recipe.target === "r3f" && !manifest.compatibility.environments.includes("react-three-fiber")) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "compatibility.environments must include \"react-three-fiber\" when an R3F recipe exists",
-          path: ["compatibility", "environments"],
-        });
-      }
-    });
+    recipeTargets.add(recipe.target);
+
+    if (recipe.target === "three" && !manifest.compatibility.environments.includes("three")) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "compatibility.environments must include \"three\" when a Three.js recipe exists",
+        path: ["compatibility", "environments"],
+      });
+    }
+
+    if (recipe.target === "r3f" && !manifest.compatibility.environments.includes("react-three-fiber")) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "compatibility.environments must include \"react-three-fiber\" when an R3F recipe exists",
+        path: ["compatibility", "environments"],
+      });
+    }
   });
+}
 
-export type ShaderManifest = z.infer<typeof shaderManifestSchema>;
+// ---------------------------------------------------------------------------
+// Base manifest fields (shared by GLSL and TSL)
+// ---------------------------------------------------------------------------
+
+const baseManifestFields = {
+  schemaVersion: z.literal("0.2.0"),
+  name: shaderNameSchema,
+  displayName: nonEmptyStringSchema,
+  version: nonEmptyStringSchema,
+  summary: nonEmptyStringSchema,
+  description: nonEmptyStringSchema,
+  author: authorSchema,
+  license: nonEmptyStringSchema,
+  tags: z.array(nonEmptyStringSchema).min(1),
+  category: nonEmptyStringSchema,
+  capabilityProfile: capabilityProfileSchema,
+  compatibility: compatibilitySchema,
+  uniforms: z.array(uniformSchema),
+  inputs: z.array(inputSchema).default([]),
+  outputs: z.array(outputSchema).min(1),
+  recipes: z.array(recipeSchema).min(1),
+  preview: previewSchema,
+  provenance: provenanceSchema,
+};
+
+// ---------------------------------------------------------------------------
+// GLSL manifest
+// ---------------------------------------------------------------------------
+
+const glslManifestObjectSchema = z.object({
+  ...baseManifestFields,
+  language: z.literal("glsl"),
+  files: fileReferencesSchema,
+});
+
+const glslManifestSchema = glslManifestObjectSchema.superRefine(validateRecipes);
+
+// ---------------------------------------------------------------------------
+// TSL manifest
+// ---------------------------------------------------------------------------
+
+const tslManifestObjectSchema = z.object({
+  ...baseManifestFields,
+  language: z.literal("tsl"),
+  tslEntry: relativePathSchema,
+});
+
+const tslManifestSchema = tslManifestObjectSchema.superRefine(validateRecipes);
+
+// ---------------------------------------------------------------------------
+// Combined manifest schema with language defaulting to "glsl"
+// ---------------------------------------------------------------------------
+
+export const shaderManifestSchema = z.preprocess(
+  (val) => {
+    if (val && typeof val === "object" && !Array.isArray(val) && !("language" in val)) {
+      return { ...(val as Record<string, unknown>), language: "glsl" };
+    }
+    return val;
+  },
+  z
+    .discriminatedUnion("language", [glslManifestObjectSchema, tslManifestObjectSchema])
+    .superRefine(validateRecipes),
+);
+
+export type GlslManifest = z.infer<typeof glslManifestSchema>;
+export type TslManifest = z.infer<typeof tslManifestSchema>;
+export type ShaderManifest = z.infer<typeof glslManifestSchema> | z.infer<typeof tslManifestSchema>;
 export type Uniform = z.infer<typeof uniformSchema>;
 export type RecipeReference = z.infer<typeof recipeSchema>;
 
 export function parseShaderManifest(input: unknown): ShaderManifest {
-  return shaderManifestSchema.parse(input);
+  return shaderManifestSchema.parse(input) as ShaderManifest;
 }
 
 export function readShaderManifestFile(filePath: string): ShaderManifest {
@@ -398,19 +453,30 @@ function makeMissingFileIssue(path: Array<string | number>, referencedPath: stri
 }
 
 export function collectReferencedFiles(manifest: ShaderManifest) {
-  return [
-    { path: manifest.files.vertex, zodPath: ["files", "vertex"] as Array<string | number> },
-    { path: manifest.files.fragment, zodPath: ["files", "fragment"] as Array<string | number> },
-    ...manifest.files.includes.map((path, index) => ({
-      path,
-      zodPath: ["files", "includes", index] as Array<string | number>,
-    })),
-    { path: manifest.preview.path, zodPath: ["preview", "path"] as Array<string | number> },
+  const files: Array<{ path: string; zodPath: Array<string | number> }> = [];
+
+  if (manifest.language === "glsl") {
+    files.push(
+      { path: manifest.files.vertex, zodPath: ["files", "vertex"] },
+      { path: manifest.files.fragment, zodPath: ["files", "fragment"] },
+      ...manifest.files.includes.map((path, index) => ({
+        path,
+        zodPath: ["files", "includes", index] as Array<string | number>,
+      })),
+    );
+  } else {
+    files.push({ path: manifest.tslEntry, zodPath: ["tslEntry"] });
+  }
+
+  files.push({ path: manifest.preview.path, zodPath: ["preview", "path"] });
+  files.push(
     ...manifest.recipes.map((recipe, index) => ({
       path: recipe.path,
       zodPath: ["recipes", index, "path"] as Array<string | number>,
     })),
-  ];
+  );
+
+  return files;
 }
 
 export function validateShaderManifestFile(filePath: string): ShaderManifest {

--- a/scripts/build-registry.test.ts
+++ b/scripts/build-registry.test.ts
@@ -29,8 +29,8 @@ try {
     assert.ok(existsSync(indexPath), "index.json should exist");
 
     const index = JSON.parse(readFileSync(indexPath, "utf8"));
-    assert.equal(index.version, "0.1.0");
-    assert.ok(index.shaders.length >= 3, `expected at least 3 shaders, got ${index.shaders.length}`);
+    assert.equal(index.version, "0.2.0");
+    assert.ok(index.shaders.length >= 4, `expected at least 4 shaders, got ${index.shaders.length}`);
   });
 
   runTest("per-shader bundle files exist", () => {
@@ -82,6 +82,26 @@ try {
     const firstUniform = gradientEntry.uniforms[0];
     assert.ok(firstUniform.name, "uniform should have a name");
     assert.ok(firstUniform.type, "uniform should have a type");
+  });
+
+  runTest("index entries include language field", () => {
+    const index = JSON.parse(readFileSync(join(tempDir, "index.json"), "utf8"));
+    for (const shader of index.shaders) {
+      assert.ok(shader.language, `shader ${shader.name} should have a language field`);
+      assert.ok(
+        shader.language === "glsl" || shader.language === "tsl",
+        `shader ${shader.name} should be glsl or tsl`,
+      );
+    }
+  });
+
+  runTest("TSL shader bundle has tslSource", () => {
+    const bundlePath = join(tempDir, "shaders", "tsl-gradient-wave.json");
+    assert.ok(existsSync(bundlePath), "tsl-gradient-wave.json bundle should exist");
+    const bundle = JSON.parse(readFileSync(bundlePath, "utf8"));
+    assert.equal(bundle.language, "tsl");
+    assert.ok(bundle.tslSource.includes("createMaterial"), "tslSource should contain createMaterial");
+    assert.equal(bundle.vertexSource, undefined, "TSL bundles should not have vertexSource");
   });
 
   runTest("index entries are sorted alphabetically by name", () => {

--- a/scripts/build-registry.ts
+++ b/scripts/build-registry.ts
@@ -55,6 +55,7 @@ export async function buildRegistry({ shadersRoot, outputDir }: BuildRegistryOpt
           ...(p.example !== undefined ? { example: p.example } : {}),
         })),
         requirements: recipe.requirements,
+        relPath: recipe.path,
       };
     }
 

--- a/scripts/build-registry.ts
+++ b/scripts/build-registry.ts
@@ -36,9 +36,8 @@ export async function buildRegistry({ shadersRoot, outputDir }: BuildRegistryOpt
 
     const manifest = validateShaderManifestFile(manifestPath);
 
-    // Read GLSL source files
-    const vertexSource = readFileSync(join(shaderDir, manifest.files.vertex), "utf8");
-    const fragmentSource = readFileSync(join(shaderDir, manifest.files.fragment), "utf8");
+    // Language is determined by the manifest's discriminated union
+    const language = manifest.language;
 
     // Build recipes record (keyed by target)
     const recipes: Record<string, RegistryRecipeBundle> = {};
@@ -113,27 +112,16 @@ export async function buildRegistry({ shadersRoot, outputDir }: BuildRegistryOpt
       renderers: manifest.compatibility.renderers,
       sourceKind: manifest.provenance.sourceKind,
       uniforms: uniformSummaries,
+      language,
     };
 
     indexEntries.push(indexEntry);
 
-    // Shader bundle
-    const bundle: RegistryShaderBundle = {
-      // Index-level fields
-      name: manifest.name,
-      displayName: manifest.displayName,
-      version: manifest.version,
-      summary: manifest.summary,
-      tags: manifest.tags,
-      category: manifest.category,
-      pipeline: manifest.capabilityProfile.pipeline,
-      stage: manifest.capabilityProfile.stage,
-      environments: manifest.compatibility.environments,
-      renderers: manifest.compatibility.renderers,
-      sourceKind: manifest.provenance.sourceKind,
-      uniforms: uniformSummaries,
+    // Shader bundle — build language-specific shape
+    let bundle: RegistryShaderBundle;
 
-      // Extended fields
+    const sharedBundleFields = {
+      ...indexEntry,
       description: manifest.description,
       author: manifest.author,
       license: manifest.license,
@@ -142,11 +130,27 @@ export async function buildRegistry({ shadersRoot, outputDir }: BuildRegistryOpt
       uniformsFull,
       inputs: manifest.inputs,
       outputs: manifest.outputs,
-      vertexSource,
-      fragmentSource,
       recipes,
       provenance,
     };
+
+    if (manifest.language === "glsl") {
+      const vertexSource = readFileSync(join(shaderDir, manifest.files.vertex), "utf8");
+      const fragmentSource = readFileSync(join(shaderDir, manifest.files.fragment), "utf8");
+      bundle = {
+        ...sharedBundleFields,
+        language: "glsl" as const,
+        vertexSource,
+        fragmentSource,
+      };
+    } else {
+      const tslSource = readFileSync(join(shaderDir, manifest.tslEntry), "utf8");
+      bundle = {
+        ...sharedBundleFields,
+        language: "tsl" as const,
+        tslSource,
+      };
+    }
 
     bundles.push({ name: manifest.name, bundle });
   }
@@ -155,7 +159,7 @@ export async function buildRegistry({ shadersRoot, outputDir }: BuildRegistryOpt
   indexEntries.sort((a, b) => a.name.localeCompare(b.name));
 
   const registryIndex: RegistryIndex = {
-    version: "0.1.0",
+    version: "0.2.0",
     generatedAt: new Date().toISOString(),
     shaders: indexEntries,
   };

--- a/shaders/gradient-radial/shader.json
+++ b/shaders/gradient-radial/shader.json
@@ -1,6 +1,7 @@
 {
-  "schemaVersion": "0.1.0",
+  "schemaVersion": "0.2.0",
   "name": "gradient-radial",
+  "language": "glsl",
   "displayName": "Radial Gradient",
   "version": "0.1.0",
   "summary": "A small surface shader that blends two colors from the UV center outward.",

--- a/shaders/simplex-displacement/shader.json
+++ b/shaders/simplex-displacement/shader.json
@@ -1,6 +1,7 @@
 {
-  "schemaVersion": "0.1.0",
+  "schemaVersion": "0.2.0",
   "name": "simplex-displacement",
+  "language": "glsl",
   "displayName": "Simplex Displacement",
   "version": "0.1.0",
   "summary": "A normal-driven displacement shader built around MIT simplex noise code.",

--- a/shaders/tsl-gradient-wave/preview.svg
+++ b/shaders/tsl-gradient-wave/preview.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1a1a2e"/>
+      <stop offset="100%" stop-color="#e94560"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" fill="url(#g)"/>
+  <text x="256" y="256" text-anchor="middle" fill="#e0e0e0" font-size="24" font-family="sans-serif">TSL Gradient Wave</text>
+</svg>

--- a/shaders/tsl-gradient-wave/recipes/three.ts
+++ b/shaders/tsl-gradient-wave/recipes/three.ts
@@ -1,0 +1,15 @@
+import { createMaterial } from '../source';
+
+/**
+ * Create a NodeMaterial with an animated gradient wave.
+ *
+ * Usage:
+ *   import { createTslGradientWaveMaterial } from './three';
+ *   const material = createTslGradientWaveMaterial();
+ *   mesh.material = material;
+ *
+ * Requires: WebGPURenderer, Three.js >= 0.170.0
+ */
+export function createTslGradientWaveMaterial() {
+  return createMaterial();
+}

--- a/shaders/tsl-gradient-wave/shader.json
+++ b/shaders/tsl-gradient-wave/shader.json
@@ -1,0 +1,75 @@
+{
+  "schemaVersion": "0.2.0",
+  "name": "tsl-gradient-wave",
+  "language": "tsl",
+  "displayName": "TSL Gradient Wave",
+  "version": "0.1.0",
+  "summary": "An animated gradient wave surface shader written in Three Shading Language.",
+  "description": "A reference TSL shader for ShaderBase. It renders an animated two-color gradient that waves using sine functions, demonstrating the TSL node-based material system with the createMaterial contract.",
+  "author": {
+    "name": "ShaderBase"
+  },
+  "license": "MIT",
+  "tags": ["tsl", "gradient", "wave", "animated", "surface"],
+  "category": "color",
+  "capabilityProfile": {
+    "pipeline": "surface",
+    "stage": "vertex-and-fragment",
+    "requires": ["uv", "time"],
+    "outputs": ["color"]
+  },
+  "compatibility": {
+    "three": ">=0.170.0",
+    "renderers": ["webgpu"],
+    "material": "node-material",
+    "environments": ["three"]
+  },
+  "uniforms": [],
+  "inputs": [
+    {
+      "name": "uv",
+      "kind": "uv",
+      "description": "Mesh UV coordinates.",
+      "required": true
+    },
+    {
+      "name": "time",
+      "kind": "time",
+      "description": "Elapsed time for animation.",
+      "required": true
+    }
+  ],
+  "outputs": [
+    {
+      "name": "surfaceColor",
+      "kind": "color",
+      "description": "Animated gradient color blended with a sine wave."
+    }
+  ],
+  "tslEntry": "source.ts",
+  "recipes": [
+    {
+      "target": "three",
+      "path": "recipes/three.ts",
+      "exportName": "createTslGradientWaveMaterial",
+      "summary": "Create a NodeMaterial with an animated gradient wave for use with WebGPURenderer.",
+      "placeholders": [],
+      "requirements": ["three-scene", "mesh"]
+    }
+  ],
+  "preview": {
+    "path": "preview.svg",
+    "format": "svg",
+    "width": 512,
+    "height": 512,
+    "deterministic": true
+  },
+  "provenance": {
+    "sourceKind": "original",
+    "sources": [],
+    "attribution": {
+      "summary": "Authored directly in the ShaderBase repository as the reference TSL shader."
+    },
+    "notes": "Seed TSL shader authored inside the repository to establish the TSL manifest contract."
+  }
+}

--- a/shaders/tsl-gradient-wave/source.ts
+++ b/shaders/tsl-gradient-wave/source.ts
@@ -1,0 +1,13 @@
+import { color, mix, uv, sin, time } from 'three/tsl';
+import { NodeMaterial } from 'three/webgpu';
+
+export function createMaterial(): NodeMaterial {
+  const material = new NodeMaterial();
+  const t = sin(time.mul(2.0)).mul(0.5).add(0.5);
+  material.colorNode = mix(
+    color(0x1a1a2e),
+    color(0xe94560),
+    mix(uv().x, uv().y, t),
+  );
+  return material;
+}

--- a/shaders/vignette-postprocess/shader.json
+++ b/shaders/vignette-postprocess/shader.json
@@ -1,6 +1,7 @@
 {
-  "schemaVersion": "0.1.0",
+  "schemaVersion": "0.2.0",
   "name": "vignette-postprocess",
+  "language": "glsl",
   "displayName": "Vignette Postprocess",
   "version": "0.1.0",
   "summary": "A screen-space vignette pass adapted from the official Three.js example shader.",


### PR DESCRIPTION
## Summary\n- fix the TSL shader detail page for both filesystem-backed and registry-backed detail loading\n- reject invalid playground language values and constrain MCP language schemas\n- add coverage for the registry-backed shader detail branches\n\n## Validation\n- bun run test:web\n- bun x tsc -p tsconfig.json --noEmit\n- bun run build:web