### PR TITLE
fix: close TSL post-merge follow-ups

### DIFF
--- a/apps/web/src/lib/server/load-shader-detail.ts
+++ b/apps/web/src/lib/server/load-shader-detail.ts
@@ -25,7 +25,7 @@ export type ShaderDetailRecipe = {
   requirements: string[]
 }
 
-export type ShaderDetail = {
+type ShaderDetailBase = {
   name: string
   displayName: string
   version: string
@@ -46,8 +46,6 @@ export type ShaderDetail = {
   uniforms: ShaderDetailUniform[]
   inputs: Array<{ name: string; kind: string; description: string; required: boolean }>
   outputs: Array<{ name: string; kind: string; description: string }>
-  vertexSource: string
-  fragmentSource: string
   recipes: ShaderDetailRecipe[]
   previewSvg: string | null
   provenance: {
@@ -69,6 +67,19 @@ export type ShaderDetail = {
   }
 }
 
+export type GlslShaderDetail = ShaderDetailBase & {
+  language: 'glsl'
+  vertexSource: string
+  fragmentSource: string
+}
+
+export type TslShaderDetail = ShaderDetailBase & {
+  language: 'tsl'
+  tslSource: string
+}
+
+export type ShaderDetail = GlslShaderDetail | TslShaderDetail
+
 /**
  * Load a single shader's full detail from its directory on disk.
  * This is the pure filesystem logic extracted from the getShaderDetail server function.
@@ -77,18 +88,13 @@ export async function loadShaderDetail(shaderDir: string): Promise<ShaderDetail>
   const manifestRaw = await readFile(join(shaderDir, 'shader.json'), 'utf8')
   const manifest = JSON.parse(manifestRaw) as Record<string, unknown>
 
-  const files = manifest.files as { vertex: string; fragment: string }
+  const language = (manifest.language as string) ?? 'glsl'
   const capabilityProfile = manifest.capabilityProfile as Record<string, unknown>
   const compatibility = manifest.compatibility as Record<string, unknown>
   const provenance = manifest.provenance as Record<string, unknown>
   const attribution = provenance.attribution as Record<string, unknown>
   const preview = manifest.preview as { path: string; format: string }
   const recipeMeta = manifest.recipes as Array<Record<string, unknown>>
-
-  const [vertexSource, fragmentSource] = await Promise.all([
-    readFile(join(shaderDir, files.vertex), 'utf8'),
-    readFile(join(shaderDir, files.fragment), 'utf8'),
-  ])
 
   const recipes: ShaderDetailRecipe[] = await Promise.all(
     recipeMeta.map(async (r) => {
@@ -109,13 +115,13 @@ export async function loadShaderDetail(shaderDir: string): Promise<ShaderDetail>
     previewSvg = await readFile(join(shaderDir, preview.path), 'utf8')
   }
 
-  return {
+  const base: Omit<ShaderDetail, 'language' | 'vertexSource' | 'fragmentSource' | 'tslSource'> = {
     name: manifest.name as string,
     displayName: manifest.displayName as string,
     version: manifest.version as string,
     summary: manifest.summary as string,
     description: manifest.description as string,
-    author: manifest.author as ShaderDetail['author'],
+    author: manifest.author as ShaderDetailBase['author'],
     license: manifest.license as string,
     tags: manifest.tags as string[],
     category: manifest.category as string,
@@ -128,15 +134,13 @@ export async function loadShaderDetail(shaderDir: string): Promise<ShaderDetail>
     material: compatibility.material as string,
     environments: compatibility.environments as string[],
     uniforms: manifest.uniforms as ShaderDetailUniform[],
-    inputs: manifest.inputs as ShaderDetail['inputs'],
-    outputs: manifest.outputs as ShaderDetail['outputs'],
-    vertexSource,
-    fragmentSource,
+    inputs: manifest.inputs as ShaderDetailBase['inputs'],
+    outputs: manifest.outputs as ShaderDetailBase['outputs'],
     recipes,
     previewSvg,
     provenance: {
       sourceKind: provenance.sourceKind as string,
-      sources: (provenance.sources as ShaderDetail['provenance']['sources']) ?? [],
+      sources: (provenance.sources as ShaderDetailBase['provenance']['sources']) ?? [],
       attribution: {
         summary: attribution.summary as string,
         requiredNotice: attribution.requiredNotice as string | undefined,
@@ -144,4 +148,17 @@ export async function loadShaderDetail(shaderDir: string): Promise<ShaderDetail>
       notes: provenance.notes as string | undefined,
     },
   }
+
+  if (language === 'tsl') {
+    const tslEntry = manifest.tslEntry as string
+    const tslSource = await readFile(join(shaderDir, tslEntry), 'utf8')
+    return { ...base, language: 'tsl', tslSource }
+  }
+
+  const files = manifest.files as { vertex: string; fragment: string }
+  const [vertexSource, fragmentSource] = await Promise.all([
+    readFile(join(shaderDir, files.vertex), 'utf8'),
+    readFile(join(shaderDir, files.fragment), 'utf8'),
+  ])
+  return { ...base, language: 'glsl', vertexSource, fragmentSource }
 }

--- a/apps/web/src/lib/server/playground-db.test.node.ts
+++ b/apps/web/src/lib/server/playground-db.test.node.ts
@@ -188,4 +188,18 @@ runTest('updateMetadata stores metadata', () => {
   assert.deepEqual(session.metadata, metadata)
 })
 
+runTest('createSession rejects invalid language', () => {
+  assert.throws(
+    () => createSession({ language: 'foo' as 'glsl' }),
+    /Invalid language "foo"/,
+  )
+})
+
+runTest('createSession rejects arbitrary language strings', () => {
+  assert.throws(
+    () => createSession({ language: 'wgsl' as 'glsl' }),
+    /Invalid language "wgsl"/,
+  )
+})
+
 console.log('playground-db tests passed')

--- a/apps/web/src/lib/server/playground-db.ts
+++ b/apps/web/src/lib/server/playground-db.ts
@@ -34,8 +34,14 @@ const DEFAULT_UNIFORMS: UniformDefinition[] = [
   { name: 'uTime', type: 'float', defaultValue: 0, description: 'Elapsed time in seconds' },
 ]
 
+const VALID_LANGUAGES = new Set(['glsl', 'tsl'])
+
 function validateCreateSessionRequest(opts?: CreateSessionRequest) {
   const language = opts?.language ?? 'glsl'
+
+  if (!VALID_LANGUAGES.has(language)) {
+    throw new Error(`Invalid language "${language}". Must be "glsl" or "tsl".`)
+  }
 
   if (language === 'glsl') {
     if ('tslSource' in (opts ?? {}) && opts?.tslSource !== undefined) {

--- a/apps/web/src/lib/server/shader-detail.ts
+++ b/apps/web/src/lib/server/shader-detail.ts
@@ -3,6 +3,8 @@ import { getShaderDetailFromSource } from './shader-source.ts'
 
 export type {
   ShaderDetail,
+  GlslShaderDetail,
+  TslShaderDetail,
   ShaderDetailUniform,
   ShaderDetailRecipe,
 } from './load-shader-detail.ts'

--- a/apps/web/src/lib/server/shader-source.ts
+++ b/apps/web/src/lib/server/shader-source.ts
@@ -1,5 +1,5 @@
 import type { ShaderEntry } from './list-shaders.ts'
-import type { ShaderDetail, ShaderDetailRecipe } from './load-shader-detail.ts'
+import type { ShaderDetail, ShaderDetailRecipe, GlslShaderDetail, TslShaderDetail } from './load-shader-detail.ts'
 
 /**
  * Environment-aware shader data source.
@@ -62,13 +62,15 @@ export async function getShaderDetailFromSource(name: string): Promise<ShaderDet
       }),
     )
 
-    return {
+    const language = (bundle.language as string) ?? 'glsl'
+
+    const base = {
       name: bundle.name as string,
       displayName: bundle.displayName as string,
       version: bundle.version as string,
       summary: bundle.summary as string,
       description: bundle.description as string,
-      author: bundle.author as ShaderDetail['author'],
+      author: bundle.author as GlslShaderDetail['author'],
       license: bundle.license as string,
       tags: bundle.tags as string[],
       category: bundle.category as string,
@@ -81,22 +83,30 @@ export async function getShaderDetailFromSource(name: string): Promise<ShaderDet
       material: compatibility.material as string,
       environments: compatibility.environments as string[],
       uniforms: uniformsFull,
-      inputs: bundle.inputs as ShaderDetail['inputs'],
-      outputs: bundle.outputs as ShaderDetail['outputs'],
-      vertexSource: bundle.vertexSource as string,
-      fragmentSource: bundle.fragmentSource as string,
+      inputs: bundle.inputs as GlslShaderDetail['inputs'],
+      outputs: bundle.outputs as GlslShaderDetail['outputs'],
       recipes,
       // previewSvg is not available in the registry bundle
       previewSvg: null,
       provenance: {
         sourceKind: provenance.sourceKind as string,
-        sources: (provenance.sources as ShaderDetail['provenance']['sources']) ?? [],
+        sources: (provenance.sources as GlslShaderDetail['provenance']['sources']) ?? [],
         attribution: {
           summary: attribution.summary as string,
           requiredNotice: attribution.requiredNotice as string | undefined,
         },
         notes: provenance.notes as string | undefined,
       },
+    }
+
+    if (language === 'tsl') {
+      return { ...base, language: 'tsl' as const, tslSource: bundle.tslSource as string }
+    }
+    return {
+      ...base,
+      language: 'glsl' as const,
+      vertexSource: bundle.vertexSource as string,
+      fragmentSource: bundle.fragmentSource as string,
     }
   }
 

--- a/apps/web/src/lib/server/shaders.test.ts
+++ b/apps/web/src/lib/server/shaders.test.ts
@@ -23,6 +23,32 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const repoRoot = resolve(__dirname, '../../../../..')
 const shadersRoot = resolve(repoRoot, 'shaders')
+const shaderSourceModuleUrl = new URL('./shader-source.ts', import.meta.url)
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+async function importShaderSourceModule(
+  cacheBust: string,
+  registryUrl = 'https://registry.example',
+) {
+  const previousRegistryUrl = process.env.REGISTRY_URL
+  process.env.REGISTRY_URL = registryUrl
+
+  try {
+    return await import(`${shaderSourceModuleUrl.href}?${cacheBust}`)
+  } finally {
+    if (previousRegistryUrl === undefined) {
+      delete process.env.REGISTRY_URL
+    } else {
+      process.env.REGISTRY_URL = previousRegistryUrl
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // listShadersFromDisk tests
@@ -170,6 +196,134 @@ async function main() {
     assert.ok('vertexSource' in detail, 'GLSL detail should have vertexSource')
     assert.ok('fragmentSource' in detail, 'GLSL detail should have fragmentSource')
     assert.ok(!('tslSource' in detail), 'GLSL detail should not have tslSource')
+  })
+
+  await runTest('getShaderDetailFromSource â€” registry-backed TSL bundle returns tslSource', async () => {
+    const { getShaderDetailFromSource } = await importShaderSourceModule('registry-tsl')
+    const originalFetch = globalThis.fetch
+
+    globalThis.fetch = (async (input) => {
+      assert.equal(String(input), 'https://registry.example/shaders/tsl-gradient-wave.json')
+      return jsonResponse({
+        name: 'tsl-gradient-wave',
+        displayName: 'TSL Gradient Wave',
+        version: '0.1.0',
+        summary: 'Registry-backed TSL shader',
+        description: 'Registry-backed TSL shader detail',
+        author: { name: 'ShaderBase' },
+        license: 'MIT',
+        tags: ['tsl', 'wave'],
+        category: 'color',
+        language: 'tsl',
+        compatibility: {
+          three: '>=0.170.0',
+          renderers: ['webgpu'],
+          material: 'node-material',
+          environments: ['three'],
+        },
+        capabilityProfile: {
+          pipeline: 'surface',
+          stage: 'vertex-and-fragment',
+          requires: ['uv', 'time'],
+          outputs: ['color'],
+        },
+        uniformsFull: [],
+        inputs: [],
+        outputs: [{ name: 'surfaceColor', kind: 'color', description: 'Color output' }],
+        recipes: {
+          three: {
+            exportName: 'createTslGradientWaveMaterial',
+            summary: 'Create a TSL material',
+            code: 'export function createTslGradientWaveMaterial() {}',
+            placeholders: [],
+            requirements: ['three-scene'],
+          },
+        },
+        provenance: {
+          sourceKind: 'original',
+          sources: [],
+          attribution: { summary: 'Created in ShaderBase' },
+        },
+        tslSource: 'export function createMaterial() {}',
+      })
+    }) as typeof fetch
+
+    try {
+      const detail = await getShaderDetailFromSource('tsl-gradient-wave')
+      assert.equal(detail.language, 'tsl')
+      assert.ok('tslSource' in detail, 'TSL detail should have tslSource')
+      assert.equal(detail.tslSource, 'export function createMaterial() {}')
+      assert.ok(!('vertexSource' in detail), 'TSL detail should not have vertexSource')
+      assert.ok(!('fragmentSource' in detail), 'TSL detail should not have fragmentSource')
+      assert.equal(detail.previewSvg, null)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  await runTest('getShaderDetailFromSource â€” registry-backed GLSL bundle returns GLSL sources', async () => {
+    const { getShaderDetailFromSource } = await importShaderSourceModule('registry-glsl')
+    const originalFetch = globalThis.fetch
+
+    globalThis.fetch = (async (input) => {
+      assert.equal(String(input), 'https://registry.example/shaders/gradient-radial.json')
+      return jsonResponse({
+        name: 'gradient-radial',
+        displayName: 'Radial Gradient',
+        version: '0.1.0',
+        summary: 'Registry-backed GLSL shader',
+        description: 'Registry-backed GLSL shader detail',
+        author: { name: 'ShaderBase' },
+        license: 'MIT',
+        tags: ['glsl', 'gradient'],
+        category: 'color',
+        language: 'glsl',
+        compatibility: {
+          three: '>=0.160.0',
+          renderers: ['webgl2'],
+          material: 'shader-material',
+          environments: ['three', 'react-three-fiber'],
+        },
+        capabilityProfile: {
+          pipeline: 'surface',
+          stage: 'vertex-and-fragment',
+          requires: ['uv', 'time'],
+          outputs: ['color'],
+        },
+        uniformsFull: [],
+        inputs: [],
+        outputs: [{ name: 'color', kind: 'color', description: 'Color output' }],
+        recipes: {
+          three: {
+            exportName: 'createGradientRadialMaterial',
+            summary: 'Create a GLSL material',
+            code: 'export function createGradientRadialMaterial() {}',
+            placeholders: [],
+            requirements: ['three-scene'],
+          },
+        },
+        provenance: {
+          sourceKind: 'original',
+          sources: [],
+          attribution: { summary: 'Created in ShaderBase' },
+        },
+        vertexSource: 'void main() { gl_Position = vec4(position, 1.0); }',
+        fragmentSource: 'void main() { gl_FragColor = vec4(1.0); }',
+      })
+    }) as typeof fetch
+
+    try {
+      const detail = await getShaderDetailFromSource('gradient-radial')
+      assert.equal(detail.language, 'glsl')
+      assert.ok('vertexSource' in detail, 'GLSL detail should have vertexSource')
+      assert.ok('fragmentSource' in detail, 'GLSL detail should have fragmentSource')
+      assert.ok(!('tslSource' in detail), 'GLSL detail should not have tslSource')
+      assert.ok(detail.vertexSource.includes('gl_Position'))
+      assert.ok(detail.fragmentSource.includes('gl_FragColor'))
+      assert.equal(detail.previewSvg, null)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
   })
 
   console.log('shaders tests passed')

--- a/apps/web/src/lib/server/shaders.test.ts
+++ b/apps/web/src/lib/server/shaders.test.ts
@@ -132,6 +132,46 @@ async function main() {
     assert.ok(detail.previewSvg!.includes('<svg'), 'previewSvg should contain SVG markup')
   })
 
+  // ---------------------------------------------------------------------------
+  // TSL shader detail tests
+  // ---------------------------------------------------------------------------
+
+  await runTest('loadShaderDetail — loads TSL shader with tslSource', async () => {
+    const detail = await loadShaderDetail(resolve(shadersRoot, 'tsl-gradient-wave'))
+    assert.equal(detail.language, 'tsl')
+    assert.equal(detail.name, 'tsl-gradient-wave')
+    assert.equal(detail.displayName, 'TSL Gradient Wave')
+    assert.ok('tslSource' in detail, 'TSL detail should have tslSource')
+    assert.ok(detail.tslSource.includes('createMaterial'), 'tslSource should contain createMaterial')
+    assert.ok(!('vertexSource' in detail), 'TSL detail should not have vertexSource')
+    assert.ok(!('fragmentSource' in detail), 'TSL detail should not have fragmentSource')
+  })
+
+  await runTest('loadShaderDetail — TSL shader has correct metadata', async () => {
+    const detail = await loadShaderDetail(resolve(shadersRoot, 'tsl-gradient-wave'))
+    assert.equal(detail.category, 'color')
+    assert.equal(detail.pipeline, 'surface')
+    assert.equal(detail.material, 'node-material')
+    assert.deepEqual(detail.renderers, ['webgpu'])
+    assert.ok(detail.tags.includes('tsl'), 'Expected "tsl" tag')
+  })
+
+  await runTest('loadShaderDetail — TSL shader loads recipes', async () => {
+    const detail = await loadShaderDetail(resolve(shadersRoot, 'tsl-gradient-wave'))
+    assert.ok(detail.recipes.length >= 1, 'Expected at least 1 recipe')
+    const threeRecipe = detail.recipes.find((r) => r.target === 'three')
+    assert.ok(threeRecipe, 'Should have a "three" recipe')
+    assert.ok(threeRecipe.code.length > 0, 'recipe code should not be empty')
+  })
+
+  await runTest('loadShaderDetail — GLSL shader has language glsl', async () => {
+    const detail = await loadShaderDetail(resolve(shadersRoot, 'gradient-radial'))
+    assert.equal(detail.language, 'glsl')
+    assert.ok('vertexSource' in detail, 'GLSL detail should have vertexSource')
+    assert.ok('fragmentSource' in detail, 'GLSL detail should have fragmentSource')
+    assert.ok(!('tslSource' in detail), 'GLSL detail should not have tslSource')
+  })
+
   console.log('shaders tests passed')
 }
 

--- a/apps/web/src/routes/shaders.$name.tsx
+++ b/apps/web/src/routes/shaders.$name.tsx
@@ -93,14 +93,29 @@ function ShaderDetailPage() {
 
             {/* Preview + Controls */}
             <div class="mb-6 grid gap-4 lg:grid-cols-[1fr_320px]">
-              <ShaderPreviewCanvas
-                vertexSource={s().vertexSource}
-                fragmentSource={s().fragmentSource}
-                uniforms={s().uniforms}
-                uniformOverrides={uniformOverrides()}
-                pipeline={s().pipeline}
-                fallbackSvg={s().previewSvg}
-              />
+              {s().language === 'tsl' ? (
+                <div class="flex aspect-square w-full items-center justify-center overflow-hidden rounded-2xl border border-surface-card-border bg-surface-primary">
+                  {s().previewSvg ? (
+                    <div class="h-full w-full" innerHTML={s().previewSvg!} />
+                  ) : (
+                    <div class="text-center">
+                      <p class="text-sm font-medium text-text-secondary">TSL Shader</p>
+                      <p class="mt-1 text-xs text-text-muted">
+                        WebGPU-based preview coming soon.
+                      </p>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <ShaderPreviewCanvas
+                  vertexSource={s().language === 'glsl' ? s().vertexSource : ''}
+                  fragmentSource={s().language === 'glsl' ? s().fragmentSource : ''}
+                  uniforms={s().uniforms}
+                  uniformOverrides={uniformOverrides()}
+                  pipeline={s().pipeline}
+                  fallbackSvg={s().previewSvg}
+                />
+              )}
               <SurfaceCard class="max-h-[500px] overflow-y-auto p-5">
                 <UniformControls
                   uniforms={s().uniforms}
@@ -238,8 +253,14 @@ function ShaderDetailPage() {
               <h2 class="text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-accent">
                 Shader Source
               </h2>
-              <CodeBlock code={s().vertexSource} language="GLSL (vertex)" />
-              <CodeBlock code={s().fragmentSource} language="GLSL (fragment)" />
+              {s().language === 'tsl' ? (
+                <CodeBlock code={s().tslSource} language="TSL (source.ts)" />
+              ) : (
+                <>
+                  <CodeBlock code={s().vertexSource} language="GLSL (vertex)" />
+                  <CodeBlock code={s().fragmentSource} language="GLSL (fragment)" />
+                </>
+              )}
             </div>
 
             {/* Provenance */}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check": "bun run test && bun run typecheck && bun run validate:shaders && bun run build:web",
     "dev:web": "cd apps/web && bun run dev",
     "test": "node --experimental-strip-types packages/schema/src/index.test.ts && bun run test:cli && bun run test:mcp && bun run test:registry && bun run test:web",
-    "test:web": "node --experimental-strip-types apps/web/src/lib/server/reviews-db.test.node.ts && node --experimental-strip-types apps/web/src/lib/server/playground-db.test.node.ts",
+    "test:web": "node --experimental-strip-types apps/web/src/lib/server/shaders.test.ts && node --experimental-strip-types apps/web/src/lib/server/reviews-db.test.node.ts && node --experimental-strip-types apps/web/src/lib/server/playground-db.test.node.ts",
     "test:cli": "node --experimental-strip-types packages/cli/src/registry-types.test.ts && node --experimental-strip-types packages/cli/src/commands/search.test.ts && node --experimental-strip-types packages/cli/src/commands/add.test.ts && node --experimental-strip-types packages/cli/src/lib/resolve-source.test.ts && node --experimental-strip-types packages/cli/src/lib/build-manifest.test.ts && node --experimental-strip-types packages/cli/src/lib/github-pr.test.ts && node --experimental-strip-types packages/cli/src/commands/submit.test.ts",
     "test:mcp": "node --experimental-strip-types packages/mcp/src/handlers.test.ts && node --experimental-strip-types packages/mcp/src/index.test.ts",
     "test:registry": "node --experimental-strip-types scripts/build-registry.test.ts",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -81,6 +81,7 @@ const TOOLS = [
         },
         language: {
           type: "string",
+          enum: ["glsl", "tsl"],
           description: "Filter by shader language ('glsl' or 'tsl').",
         },
       },
@@ -136,6 +137,7 @@ const TOOLS = [
         fragmentSource: { type: "string", description: "Initial fragment shader GLSL source." },
         language: {
           type: "string",
+          enum: ["glsl", "tsl"],
           description: "Shader language: 'glsl' (default) or 'tsl'.",
         },
         tslSource: {
@@ -245,6 +247,7 @@ const TOOLS_MCP_FORMAT = [
         },
         language: {
           type: "string",
+          enum: ["glsl", "tsl"],
           description: "Filter by shader language ('glsl' or 'tsl').",
         },
       },
@@ -301,6 +304,7 @@ const TOOLS_MCP_FORMAT = [
         },
         language: {
           type: "string",
+          enum: ["glsl", "tsl"],
           description: "Shader language: 'glsl' (default) or 'tsl'.",
         },
         tslSource: {


### PR DESCRIPTION
## Summary\n- fix the TSL shader detail page for both filesystem-backed and registry-backed detail loading\n- reject invalid playground language values and constrain MCP language schemas\n- add coverage for the registry-backed shader detail branches\n\n## Validation\n- bun run test:web\n- bun x tsc -p tsconfig.json --noEmit\n- bun run build:web