### PR TITLE
ci: separate development and production registries

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -47,7 +47,7 @@ jobs:
 
   deploy-registry:
     needs: check
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/development')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -69,11 +69,19 @@ jobs:
       - name: Build Registry
         run: bun run build:registry
 
-      - name: Deploy to Cloudflare Pages
+      - name: Deploy Registry (production)
+        if: github.ref == 'refs/heads/master'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          command: pages deploy dist/registry --project-name=shaderbase-registry
+          command: pages deploy dist/registry --project-name=shaderbase-registry --branch=master
+
+      - name: Deploy Registry (development)
+        if: github.ref == 'refs/heads/development'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: pages deploy dist/registry --project-name=shaderbase-registry --branch=development
 
   # Web app deployment is pending — SolidJS + TanStack Start + Cloudflare Workers
   # has a known bundling issue (ssrStyleProperty not exported in worker mode).

--- a/packages/mcp/wrangler.toml
+++ b/packages/mcp/wrangler.toml
@@ -10,5 +10,5 @@ WEB_APP_URL = "https://shaderbase.com"
 name = "shaderbase-mcp-dev"
 
 [env.development.vars]
-REGISTRY_URL = "https://registry.shaderbase.com"
+REGISTRY_URL = "https://development.shaderbase-registry.pages.dev"
 WEB_APP_URL = "https://blissful-acceptance-development.up.railway.app"


### PR DESCRIPTION
## Summary\n- deploy the registry on both master and development\n- publish development registry content to the Pages development branch alias\n- point the MCP development environment at the development registry URL\n\n## Expected outcome\n- prod web/MCP read from prod registry\n- dev web/MCP read from dev registry\n\n## Notes\n- Railway development REGISTRY_URL will be updated after this lands and the dev registry alias is live