### PR TITLE
feat: add live TSL previews across detail pages and playground

### DIFF
--- a/apps/web/src/components/TslPreviewCanvas.tsx
+++ b/apps/web/src/components/TslPreviewCanvas.tsx
@@ -1,0 +1,281 @@
+import { createEffect, createSignal, on, onCleanup, onMount } from 'solid-js'
+import type {
+  TslPreviewModuleResult,
+  TslPreviewModuleRuntime,
+} from '../../../../packages/schema/src/tsl-preview-module.ts'
+
+type THREE = typeof import('three/webgpu')
+type TSL = typeof import('three/tsl')
+
+type TslPreviewCanvasProps = {
+  previewModule: string
+  pipeline: string
+  fallbackSvg?: string | null
+  onError?: (errors: string[]) => void
+  onScreenshotReady?: (base64: string) => void
+}
+
+type LoadedRuntime = {
+  THREE: THREE
+  TSL: TSL
+}
+
+type PreviewInstance = TslPreviewModuleResult & {
+  material: InstanceType<THREE['Material']>
+}
+
+type PreviewModuleNamespace = {
+  createPreview: (runtime: TslPreviewModuleRuntime) => TslPreviewModuleResult
+}
+
+function defaultGeometry(THREE: THREE, pipeline: string) {
+  if (pipeline === 'postprocessing') {
+    return new THREE.PlaneGeometry(2, 2)
+  }
+
+  if (pipeline === 'geometry') {
+    return new THREE.SphereGeometry(1, 32, 32)
+  }
+
+  return new THREE.PlaneGeometry(2, 2, 1, 1)
+}
+
+export default function TslPreviewCanvas(props: TslPreviewCanvasProps) {
+  let containerRef!: HTMLDivElement
+  let renderer: InstanceType<THREE['WebGPURenderer']> | null = null
+  let scene: InstanceType<THREE['Scene']> | null = null
+  let camera: InstanceType<THREE['Camera']> | null = null
+  let mesh: InstanceType<THREE['Mesh']> | null = null
+  let runtime: LoadedRuntime | null = null
+  let previewInstance: PreviewInstance | null = null
+  let animationId = 0
+  let currentModuleUrl: string | null = null
+
+  const [loading, setLoading] = createSignal(true)
+  const [error, setError] = createSignal('')
+
+  function setPreviewError(message: string) {
+    setError(message)
+    props.onError?.([message])
+  }
+
+  function clearPreviewError() {
+    setError('')
+    props.onError?.([])
+  }
+
+  function captureScreenshot() {
+    if (!renderer || !props.onScreenshotReady) return
+
+    try {
+      const base64 = renderer.domElement.toDataURL('image/png')
+      props.onScreenshotReady(base64)
+    } catch {
+      // Ignore screenshot failures. The preview can still be useful without one.
+    }
+  }
+
+  function disposePreviewMesh() {
+    if (previewInstance?.dispose) {
+      previewInstance.dispose()
+    }
+
+    previewInstance = null
+
+    if (mesh && scene) {
+      scene.remove(mesh)
+      mesh.geometry?.dispose()
+      mesh.material?.dispose()
+    }
+
+    mesh = null
+
+    if (currentModuleUrl) {
+      URL.revokeObjectURL(currentModuleUrl)
+      currentModuleUrl = null
+    }
+  }
+
+  async function renderPreview(previewModule: string) {
+    if (!runtime || !renderer || !scene || !camera) return
+
+    disposePreviewMesh()
+
+    try {
+      const width = containerRef.clientWidth
+      const height = containerRef.clientHeight || 400
+      const blob = new Blob([previewModule], { type: 'text/javascript' })
+      currentModuleUrl = URL.createObjectURL(blob)
+
+      const module = (await import(/* @vite-ignore */ currentModuleUrl)) as PreviewModuleNamespace
+      if (typeof module.createPreview !== 'function') {
+        throw new Error('TSL preview modules must export createPreview(runtime).')
+      }
+
+      const nextPreview = module.createPreview({
+        THREE: runtime.THREE,
+        TSL: runtime.TSL,
+        width,
+        height,
+        pipeline: props.pipeline,
+      })
+
+      if (!nextPreview?.material || typeof nextPreview.material !== 'object') {
+        throw new Error('createPreview(runtime) must return an object with a material.')
+      }
+
+      previewInstance = nextPreview as PreviewInstance
+
+      const geometry = (previewInstance.geometry as InstanceType<THREE['BufferGeometry']> | undefined)
+        ?? defaultGeometry(runtime.THREE, props.pipeline)
+
+      const nextCamera = previewInstance.camera as InstanceType<THREE['Camera']> | undefined
+      if (nextCamera) {
+        camera = nextCamera
+      }
+
+      mesh = new runtime.THREE.Mesh(geometry, previewInstance.material)
+      scene.add(mesh)
+      renderer.render(scene, camera)
+      clearPreviewError()
+      captureScreenshot()
+    } catch (previewError) {
+      disposePreviewMesh()
+      setPreviewError(
+        previewError instanceof Error
+          ? previewError.message
+          : 'Failed to build the TSL preview module.',
+      )
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  onMount(async () => {
+    if (!('gpu' in navigator)) {
+      setPreviewError('WebGPU is not available in this browser.')
+      setLoading(false)
+      return
+    }
+
+    try {
+      const [THREE, TSL] = await Promise.all([
+        import('three/webgpu'),
+        import('three/tsl'),
+      ])
+
+      const width = containerRef.clientWidth
+      const height = containerRef.clientHeight || 400
+
+      renderer = new THREE.WebGPURenderer({
+        antialias: true,
+        alpha: true,
+        powerPreference: 'high-performance',
+      })
+      await renderer.init()
+
+      renderer.setSize(width, height)
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
+      containerRef.appendChild(renderer.domElement)
+      renderer.domElement.style.display = 'block'
+      renderer.domElement.style.width = '100%'
+      renderer.domElement.style.height = '100%'
+      renderer.domElement.style.borderRadius = '1rem'
+
+      scene = new THREE.Scene()
+      camera = props.pipeline === 'postprocessing'
+        ? new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 10)
+        : new THREE.PerspectiveCamera(45, width / height, 0.1, 100)
+      camera.position.z = props.pipeline === 'postprocessing' ? 1 : 3
+
+      runtime = { THREE, TSL }
+
+      const animate = () => {
+        if (!renderer || !scene || !camera) return
+        animationId = requestAnimationFrame(animate)
+
+        if (props.pipeline === 'geometry' && mesh) {
+          const elapsed = performance.now() * 0.001
+          mesh.rotation.y = elapsed * 0.3
+          mesh.rotation.x = elapsed * 0.15
+        }
+
+        previewInstance?.update?.(performance.now() * 0.001)
+        renderer.render(scene, camera)
+      }
+
+      const handleResize = () => {
+        if (!renderer || !camera || !runtime) return
+        const nextWidth = containerRef.clientWidth
+        const nextHeight = containerRef.clientHeight || 400
+        renderer.setSize(nextWidth, nextHeight)
+
+        if (camera instanceof runtime.THREE.PerspectiveCamera) {
+          camera.aspect = nextWidth / nextHeight
+          camera.updateProjectionMatrix()
+        }
+      }
+
+      window.addEventListener('resize', handleResize)
+      onCleanup(() => {
+        window.removeEventListener('resize', handleResize)
+        if (animationId) cancelAnimationFrame(animationId)
+        animationId = 0
+        disposePreviewMesh()
+        renderer?.domElement.remove()
+        renderer?.dispose()
+        renderer = null
+        scene = null
+        camera = null
+        runtime = null
+      })
+
+      animate()
+      await renderPreview(props.previewModule)
+    } catch (previewError) {
+      setPreviewError(
+        previewError instanceof Error
+          ? previewError.message
+          : 'Failed to initialize the TSL preview runtime.',
+      )
+      setLoading(false)
+    }
+  })
+
+  createEffect(
+    on(
+      () => props.previewModule,
+      async (previewModule) => {
+        if (!runtime || !renderer) return
+        setLoading(true)
+        await renderPreview(previewModule)
+      },
+      { defer: true },
+    ),
+  )
+
+  return (
+    <div
+      ref={containerRef}
+      class="relative aspect-square w-full overflow-hidden rounded-2xl border border-surface-card-border bg-surface-primary"
+    >
+      {loading() && (
+        <div class="absolute inset-0 flex items-center justify-center">
+          <div class="h-6 w-6 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+        </div>
+      )}
+      {error() && (
+        <div class="absolute inset-0 flex items-center justify-center p-4">
+          {props.fallbackSvg ? (
+            <div class="h-full w-full" innerHTML={props.fallbackSvg} />
+          ) : (
+            <div class="text-center">
+              <p class="text-sm font-medium text-danger">Preview unavailable</p>
+              <p class="mt-1 text-xs text-text-muted">{error()}</p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/playground/PlaygroundCanvas.tsx
+++ b/apps/web/src/components/playground/PlaygroundCanvas.tsx
@@ -1,10 +1,13 @@
-import { createEffect, createSignal, on, onCleanup, onMount } from 'solid-js'
+import { createEffect, createMemo, createSignal, on, onCleanup, onMount } from 'solid-js'
+import { buildTslPreviewModule } from '../../../../../packages/schema/src/tsl-preview-module.ts'
+import TslPreviewCanvas from '../TslPreviewCanvas'
 
 type THREE = typeof import('three')
 
 type PlaygroundCanvasProps = {
   vertexSource: string
   fragmentSource: string
+  tslSource?: string
   pipeline: string
   language: 'glsl' | 'tsl'
   onError: (errors: string[]) => void
@@ -19,6 +22,28 @@ function buildDefaultUniforms(THREE: THREE) {
 }
 
 export default function PlaygroundCanvas(props: PlaygroundCanvasProps) {
+  const tslPreviewModule = createMemo(() => {
+    if (props.language !== 'tsl' || !props.tslSource) return ''
+
+    try {
+      return buildTslPreviewModule(props.tslSource)
+    } catch (error) {
+      props.onError([error instanceof Error ? error.message : 'Failed to build TSL preview module'])
+      return ''
+    }
+  })
+
+  if (props.language === 'tsl') {
+    return (
+      <TslPreviewCanvas
+        previewModule={tslPreviewModule()}
+        pipeline={props.pipeline}
+        onError={props.onError}
+        onScreenshotReady={props.onScreenshotReady}
+      />
+    )
+  }
+
   let containerRef!: HTMLDivElement
   let renderer: InstanceType<THREE['WebGLRenderer']> | null = null
   let material: InstanceType<THREE['ShaderMaterial']> | null = null
@@ -33,12 +58,6 @@ export default function PlaygroundCanvas(props: PlaygroundCanvasProps) {
   const [initError, setInitError] = createSignal('')
 
   onMount(async () => {
-    // TSL preview not yet implemented — show placeholder
-    if (props.language === 'tsl') {
-      setLoading(false)
-      return
-    }
-
     let THREE: THREE
     try {
       THREE = await import('three')
@@ -254,7 +273,7 @@ export default function PlaygroundCanvas(props: PlaygroundCanvasProps) {
     on(
       () => [props.vertexSource, props.fragmentSource] as const,
       ([vertex, fragment]) => {
-        if (!threeModule || !renderer || props.language === 'tsl') return
+        if (!threeModule || !renderer) return
         compileShader(threeModule, vertex, fragment)
       },
       { defer: true },
@@ -274,16 +293,6 @@ export default function PlaygroundCanvas(props: PlaygroundCanvasProps) {
       {initError() && (
         <div class="absolute inset-0 flex items-center justify-center p-4">
           <p class="text-sm text-danger">{initError()}</p>
-        </div>
-      )}
-      {!loading() && props.language === 'tsl' && (
-        <div class="absolute inset-0 flex items-center justify-center p-4">
-          <div class="text-center">
-            <p class="text-sm font-medium text-text-secondary">TSL Preview</p>
-            <p class="mt-1 text-xs text-text-muted">
-              WebGPU-based TSL preview coming soon.
-            </p>
-          </div>
         </div>
       )}
     </div>

--- a/apps/web/src/components/playground/PlaygroundLayout.tsx
+++ b/apps/web/src/components/playground/PlaygroundLayout.tsx
@@ -182,6 +182,7 @@ export default function PlaygroundLayout(props: PlaygroundLayoutProps) {
             <PlaygroundCanvas
               vertexSource={vertexSource()}
               fragmentSource={fragmentSource()}
+              tslSource={tslSource()}
               pipeline={props.session.pipeline}
               language={props.session.language}
               onError={handleErrors}

--- a/apps/web/src/lib/server/load-shader-detail.ts
+++ b/apps/web/src/lib/server/load-shader-detail.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { buildTslPreviewModule } from '../../../../../packages/schema/src/tsl-preview-module.ts'
 
 export type ShaderDetailUniform = {
   name: string
@@ -76,6 +77,7 @@ export type GlslShaderDetail = ShaderDetailBase & {
 export type TslShaderDetail = ShaderDetailBase & {
   language: 'tsl'
   tslSource: string
+  previewModule: string
 }
 
 export type ShaderDetail = GlslShaderDetail | TslShaderDetail
@@ -115,7 +117,7 @@ export async function loadShaderDetail(shaderDir: string): Promise<ShaderDetail>
     previewSvg = await readFile(join(shaderDir, preview.path), 'utf8')
   }
 
-  const base: Omit<ShaderDetail, 'language' | 'vertexSource' | 'fragmentSource' | 'tslSource'> = {
+  const base: Omit<ShaderDetail, 'language' | 'vertexSource' | 'fragmentSource' | 'tslSource' | 'previewModule'> = {
     name: manifest.name as string,
     displayName: manifest.displayName as string,
     version: manifest.version as string,
@@ -152,7 +154,7 @@ export async function loadShaderDetail(shaderDir: string): Promise<ShaderDetail>
   if (language === 'tsl') {
     const tslEntry = manifest.tslEntry as string
     const tslSource = await readFile(join(shaderDir, tslEntry), 'utf8')
-    return { ...base, language: 'tsl', tslSource }
+    return { ...base, language: 'tsl', tslSource, previewModule: buildTslPreviewModule(tslSource) }
   }
 
   const files = manifest.files as { vertex: string; fragment: string }

--- a/apps/web/src/lib/server/shader-source.ts
+++ b/apps/web/src/lib/server/shader-source.ts
@@ -86,8 +86,7 @@ export async function getShaderDetailFromSource(name: string): Promise<ShaderDet
       inputs: bundle.inputs as GlslShaderDetail['inputs'],
       outputs: bundle.outputs as GlslShaderDetail['outputs'],
       recipes,
-      // previewSvg is not available in the registry bundle
-      previewSvg: null,
+      previewSvg: (bundle.previewSvg as string | undefined) ?? null,
       provenance: {
         sourceKind: provenance.sourceKind as string,
         sources: (provenance.sources as GlslShaderDetail['provenance']['sources']) ?? [],
@@ -100,7 +99,12 @@ export async function getShaderDetailFromSource(name: string): Promise<ShaderDet
     }
 
     if (language === 'tsl') {
-      return { ...base, language: 'tsl' as const, tslSource: bundle.tslSource as string }
+      return {
+        ...base,
+        language: 'tsl' as const,
+        tslSource: bundle.tslSource as string,
+        previewModule: bundle.previewModule as string,
+      }
     }
     return {
       ...base,

--- a/apps/web/src/lib/server/shaders.test.ts
+++ b/apps/web/src/lib/server/shaders.test.ts
@@ -168,7 +168,9 @@ async function main() {
     assert.equal(detail.name, 'tsl-gradient-wave')
     assert.equal(detail.displayName, 'TSL Gradient Wave')
     assert.ok('tslSource' in detail, 'TSL detail should have tslSource')
+    assert.ok('previewModule' in detail, 'TSL detail should have previewModule')
     assert.ok(detail.tslSource.includes('createMaterial'), 'tslSource should contain createMaterial')
+    assert.ok(detail.previewModule.includes('createPreview'), 'previewModule should contain createPreview')
     assert.ok(!('vertexSource' in detail), 'TSL detail should not have vertexSource')
     assert.ok(!('fragmentSource' in detail), 'TSL detail should not have fragmentSource')
   })
@@ -244,7 +246,9 @@ async function main() {
           sources: [],
           attribution: { summary: 'Created in ShaderBase' },
         },
+        previewSvg: '<svg><text>TSL Preview</text></svg>',
         tslSource: 'export function createMaterial() {}',
+        previewModule: 'export function createPreview() { return { material: {} }; }',
       })
     }) as typeof fetch
 
@@ -252,10 +256,12 @@ async function main() {
       const detail = await getShaderDetailFromSource('tsl-gradient-wave')
       assert.equal(detail.language, 'tsl')
       assert.ok('tslSource' in detail, 'TSL detail should have tslSource')
+      assert.ok('previewModule' in detail, 'TSL detail should have previewModule')
       assert.equal(detail.tslSource, 'export function createMaterial() {}')
+      assert.equal(detail.previewModule, 'export function createPreview() { return { material: {} }; }')
       assert.ok(!('vertexSource' in detail), 'TSL detail should not have vertexSource')
       assert.ok(!('fragmentSource' in detail), 'TSL detail should not have fragmentSource')
-      assert.equal(detail.previewSvg, null)
+      assert.equal(detail.previewSvg, '<svg><text>TSL Preview</text></svg>')
     } finally {
       globalThis.fetch = originalFetch
     }
@@ -307,6 +313,7 @@ async function main() {
           sources: [],
           attribution: { summary: 'Created in ShaderBase' },
         },
+        previewSvg: '<svg><text>GLSL Preview</text></svg>',
         vertexSource: 'void main() { gl_Position = vec4(position, 1.0); }',
         fragmentSource: 'void main() { gl_FragColor = vec4(1.0); }',
       })
@@ -320,7 +327,7 @@ async function main() {
       assert.ok(!('tslSource' in detail), 'GLSL detail should not have tslSource')
       assert.ok(detail.vertexSource.includes('gl_Position'))
       assert.ok(detail.fragmentSource.includes('gl_FragColor'))
-      assert.equal(detail.previewSvg, null)
+      assert.equal(detail.previewSvg, '<svg><text>GLSL Preview</text></svg>')
     } finally {
       globalThis.fetch = originalFetch
     }

--- a/apps/web/src/routes/api/playground/$.ts
+++ b/apps/web/src/routes/api/playground/$.ts
@@ -92,7 +92,7 @@ async function handlePlayground(request: Request): Promise<Response> {
       const response: CreateSessionResponse = {
         sessionId: created.id,
         url: `${WEB_URL}/playground?session=${created.id}`,
-        previewAvailable: created.session.language === 'glsl',
+        previewAvailable: true,
       }
       return jsonResponse(response, 201)
     } catch (error) {
@@ -168,12 +168,12 @@ async function handlePlayground(request: Request): Promise<Response> {
       return badRequestResponse(error instanceof Error ? error.message : 'Invalid shader update request')
     }
 
-    const previewAvailable = session.language === 'glsl'
+    const previewAvailable = true
 
-    // Wait for screenshot from browser — only for GLSL (TSL preview not yet implemented)
+    // Wait for screenshot from the browser when it is connected.
     const browserConnected = hasSSEConnections(sessionId)
     let screenshotBase64: string | null = null
-    if (browserConnected && previewAvailable) {
+    if (browserConnected) {
       screenshotBase64 = await waitForScreenshot(sessionId, SCREENSHOT_WAIT_MS)
     }
 

--- a/apps/web/src/routes/shaders.$name.tsx
+++ b/apps/web/src/routes/shaders.$name.tsx
@@ -5,6 +5,7 @@ import { getShaderDetail, type ShaderDetail } from '../lib/server/shader-detail'
 import { getReviews } from './api/-reviews'
 import type { Review, ReviewStats } from '../lib/server/reviews-db'
 import ShaderPreviewCanvas from '../components/ShaderPreviewCanvas'
+import TslPreviewCanvas from '../components/TslPreviewCanvas'
 import UniformControls from '../components/UniformControls'
 import CodeBlock from '../components/CodeBlock'
 import ReviewsSection from '../components/ReviewsSection'
@@ -94,18 +95,11 @@ function ShaderDetailPage() {
             {/* Preview + Controls */}
             <div class="mb-6 grid gap-4 lg:grid-cols-[1fr_320px]">
               {s().language === 'tsl' ? (
-                <div class="flex aspect-square w-full items-center justify-center overflow-hidden rounded-2xl border border-surface-card-border bg-surface-primary">
-                  {s().previewSvg ? (
-                    <div class="h-full w-full" innerHTML={s().previewSvg!} />
-                  ) : (
-                    <div class="text-center">
-                      <p class="text-sm font-medium text-text-secondary">TSL Shader</p>
-                      <p class="mt-1 text-xs text-text-muted">
-                        WebGPU-based preview coming soon.
-                      </p>
-                    </div>
-                  )}
-                </div>
+                <TslPreviewCanvas
+                  previewModule={s().previewModule}
+                  pipeline={s().pipeline}
+                  fallbackSvg={s().previewSvg}
+                />
               ) : (
                 <ShaderPreviewCanvas
                   vertexSource={s().language === 'glsl' ? s().vertexSource : ''}

--- a/packages/cli/src/commands/add.test.ts
+++ b/packages/cli/src/commands/add.test.ts
@@ -201,6 +201,7 @@ runTest("writes TSL shader with recipe in subdirectory using relPath", () => {
       inputs: [],
       outputs: [{ name: "color", kind: "color", description: "Output color" }],
       tslSource: "export function createMaterial() { /* TSL */ }",
+      previewModule: "export function createPreview() { return { material: {} }; }",
       recipes: {
         three: {
           exportName: "createTslGradientWaveMaterial",

--- a/packages/cli/src/registry-types.test.ts
+++ b/packages/cli/src/registry-types.test.ts
@@ -106,6 +106,7 @@ function makeValidShaderBundle() {
         summary: "Original shader by ShaderBase contributors.",
       },
     },
+    previewSvg: "<svg></svg>",
   };
 }
 
@@ -143,6 +144,7 @@ function makeValidTslBundle() {
       { name: "fragColor", kind: "color", description: "Output fragment color" },
     ],
     tslSource: "import { uniform, uv, vec4 } from 'three/tsl';\nexport const noiseMaterial = () => vec4(uv(), 0.0, 1.0);",
+    previewModule: "export function createPreview() { return { material: {} }; }",
     recipes: {
       three: {
         exportName: "createNoiseMaterial",
@@ -159,6 +161,7 @@ function makeValidTslBundle() {
         summary: "Original shader by ShaderBase contributors.",
       },
     },
+    previewSvg: "<svg></svg>",
   };
 }
 
@@ -223,6 +226,14 @@ runTest("rejects TSL bundle without tslSource", () => {
   const bundle = makeValidTslBundle();
   const { tslSource: _, ...withoutTsl } = bundle;
   const result = registryShaderBundleSchema.safeParse(withoutTsl);
+
+  assert.equal(result.success, false);
+});
+
+runTest("rejects TSL bundle without previewModule", () => {
+  const bundle = makeValidTslBundle();
+  const { previewModule: _, ...withoutPreviewModule } = bundle;
+  const result = registryShaderBundleSchema.safeParse(withoutPreviewModule);
 
   assert.equal(result.success, false);
 });

--- a/packages/cli/src/registry-types.ts
+++ b/packages/cli/src/registry-types.ts
@@ -198,6 +198,7 @@ const registryShaderBundleBaseFields = {
   outputs: z.array(registryOutputSchema),
   recipes: z.record(z.string(), registryRecipeBundleSchema),
   provenance: registryProvenanceSchema,
+  previewSvg: z.string().min(1).optional(),
 };
 
 const registryGlslBundleSchema = z.object({
@@ -211,6 +212,7 @@ const registryTslBundleSchema = z.object({
   ...registryShaderBundleBaseFields,
   language: z.literal("tsl"),
   tslSource: z.string().min(1),
+  previewModule: z.string().min(1),
 });
 
 export const registryShaderBundleSchema = z.discriminatedUnion("language", [

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -129,7 +129,7 @@ const TOOLS = [
   {
     name: "create_playground",
     description:
-      "Create a new shader playground session. GLSL sessions have visual preview; TSL sessions support editing only (previewAvailable flag indicates status).",
+      "Create a new shader playground session for live editing and preview.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -168,7 +168,7 @@ const TOOLS = [
   {
     name: "update_shader",
     description:
-      "Update shader source in a playground session. Returns compilation errors, structured errors, and a screenshot (GLSL only).",
+      "Update shader source in a playground session. Returns compilation errors, structured errors, and a screenshot when a browser preview is connected.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -290,7 +290,7 @@ const TOOLS_MCP_FORMAT = [
   {
     name: "create_playground",
     description:
-      "Create a new shader playground session for live editing. Supports both GLSL and TSL languages. GLSL sessions have full visual preview with screenshots. TSL sessions support source editing but preview is not yet available (previewAvailable will be false). Returns a session ID, URL, and previewAvailable flag.",
+      "Create a new shader playground session for live editing. Supports both GLSL and TSL languages. When a browser has the playground open, both can render a live preview and return screenshots. Returns a session ID, URL, and previewAvailable flag.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -337,7 +337,7 @@ const TOOLS_MCP_FORMAT = [
   {
     name: "update_shader",
     description:
-      "Update shader source in a playground session. For GLSL sessions, provide vertexSource/fragmentSource. For TSL sessions, provide tslSource. Returns compilation errors, structured errors (with kind and message), and a screenshot for GLSL sessions. The previewAvailable flag indicates whether screenshots are supported.",
+      "Update shader source in a playground session. For GLSL sessions, provide vertexSource/fragmentSource. For TSL sessions, provide tslSource. Returns compilation errors, structured errors (with kind and message), and a screenshot when a browser preview is connected. The previewAvailable flag indicates the session supports live preview.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -364,7 +364,7 @@ const TOOLS_MCP_FORMAT = [
   {
     name: "get_preview",
     description:
-      "Get the latest screenshot from a playground session. Only available for GLSL sessions (TSL preview not yet implemented). Returns the most recent rendered frame as a PNG image.",
+      "Get the latest screenshot from a playground session. Returns the most recent rendered frame as a PNG image when a browser preview has uploaded one.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -563,11 +563,6 @@ async function handleMcpToolCall(
       const base64Data = result.screenshotBase64.replace(/^data:image\/png;base64,/, "");
       return {
         content: [{ type: "image", data: base64Data, mimeType: "image/png" }],
-      };
-    }
-    if (result.language === "tsl") {
-      return {
-        content: [{ type: "text", text: "Preview not available for TSL sessions. TSL preview requires WebGPU which is not yet implemented." }],
       };
     }
     return {

--- a/packages/mcp/src/playground-handlers.test.ts
+++ b/packages/mcp/src/playground-handlers.test.ts
@@ -86,16 +86,16 @@ async function main() {
     assert.equal(result.previewAvailable, true);
   });
 
-  await runTest("create_playground TSL session returns previewAvailable false", async () => {
+  await runTest("create_playground TSL session returns previewAvailable true", async () => {
     const mockFetch = createMockFetch({
       "/api/playground/create": {
         status: 200,
-        body: { sessionId: "tsl-1", url: "https://test.shaderbase.com/playground?session=tsl-1", previewAvailable: false },
+        body: { sessionId: "tsl-1", url: "https://test.shaderbase.com/playground?session=tsl-1", previewAvailable: true },
       },
     });
 
     const result = await handleCreatePlayground({ language: "tsl", tslSource: "// tsl" }, env, mockFetch);
-    assert.equal(result.previewAvailable, false);
+    assert.equal(result.previewAvailable, true);
   });
 
   await runTest("create_playground forwards custom GLSL", async () => {
@@ -159,7 +159,7 @@ async function main() {
           structuredErrors: [{ kind: "tsl-parse", message: "Unexpected token at line 3" }],
           screenshotBase64: null,
           browserConnected: false,
-          previewAvailable: false,
+          previewAvailable: true,
         },
       },
     });
@@ -171,7 +171,7 @@ async function main() {
     );
     assert.equal(result.structuredErrors.length, 1);
     assert.equal(result.structuredErrors[0]!.kind, "tsl-parse");
-    assert.equal(result.previewAvailable, false);
+    assert.equal(result.previewAvailable, true);
     assert.equal(result.screenshotBase64, null);
   });
 

--- a/packages/schema/src/tsl-preview-module.ts
+++ b/packages/schema/src/tsl-preview-module.ts
@@ -1,0 +1,99 @@
+type ImportBinding = {
+  imported: string
+  local: string
+}
+
+export type TslPreviewModuleRuntime = {
+  THREE: unknown
+  TSL: unknown
+  width: number
+  height: number
+  pipeline: string
+}
+
+export type TslPreviewModuleResult = {
+  material: unknown
+  geometry?: unknown
+  camera?: unknown
+  update?: (time: number) => void
+  dispose?: () => void
+}
+
+function parseImportBindings(specifierList: string): ImportBinding[] {
+  return specifierList
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .map((item) => {
+      const [imported = '', local] = item.split(/\s+as\s+/)
+      return {
+        imported: imported.trim(),
+        local: (local ?? imported).trim(),
+      }
+    })
+}
+
+function buildDestructureLine(namespace: string, bindings: ImportBinding[]) {
+  if (bindings.length === 0) return ''
+
+  const entries = bindings.map((binding) =>
+    binding.imported === binding.local
+      ? binding.imported
+      : `${binding.imported}: ${binding.local}`,
+  )
+
+  return `const { ${entries.join(', ')} } = ${namespace};`
+}
+
+function normalizeTslSource(sourceCode: string) {
+  const importPattern = /^import\s*{\s*([^}]+)\s*}\s*from\s*['"]([^'"]+)['"];?\s*$/gm
+  const tslBindings: ImportBinding[] = []
+  const webgpuBindings: ImportBinding[] = []
+
+  const strippedSource = sourceCode.replace(importPattern, (_match, specifiers: string, from: string) => {
+    const bindings = parseImportBindings(specifiers)
+
+    if (from === 'three/tsl') {
+      tslBindings.push(...bindings)
+      return ''
+    }
+
+    if (from === 'three/webgpu') {
+      webgpuBindings.push(...bindings)
+      return ''
+    }
+
+    throw new Error(`Unsupported TSL import source: ${from}`)
+  })
+
+  const normalizedSource = strippedSource
+    .replace(/export\s+function\s+createMaterial\s*\(/, 'function createMaterial(')
+    .replace(/\)\s*:\s*[A-Za-z0-9_<>\[\]\s,.|]+\s*\{/g, ') {')
+    .replace(/export\s+const\s+createMaterial\s*=/, 'const createMaterial =')
+
+  return {
+    normalizedSource,
+    tslBindings,
+    webgpuBindings,
+  }
+}
+
+export function buildTslPreviewModule(sourceCode: string) {
+  const { normalizedSource, tslBindings, webgpuBindings } = normalizeTslSource(sourceCode)
+
+  const moduleBody = [
+    buildDestructureLine('TSL', tslBindings),
+    buildDestructureLine('THREE', webgpuBindings),
+    normalizedSource.trim(),
+    `
+export function createPreview(runtime) {
+  const material = createMaterial();
+  return { material };
+}
+`.trim(),
+  ]
+    .filter(Boolean)
+    .join('\n\n')
+
+  return `${moduleBody}\n`
+}

--- a/scripts/build-registry.test.ts
+++ b/scripts/build-registry.test.ts
@@ -101,7 +101,16 @@ try {
     const bundle = JSON.parse(readFileSync(bundlePath, "utf8"));
     assert.equal(bundle.language, "tsl");
     assert.ok(bundle.tslSource.includes("createMaterial"), "tslSource should contain createMaterial");
+    assert.ok(bundle.previewModule.includes("createPreview"), "previewModule should contain createPreview");
     assert.equal(bundle.vertexSource, undefined, "TSL bundles should not have vertexSource");
+  });
+
+  runTest("SVG previews are inlined into shader bundles", () => {
+    const bundle = JSON.parse(
+      readFileSync(join(tempDir, "shaders", "tsl-gradient-wave.json"), "utf8"),
+    );
+    assert.ok(bundle.previewSvg, "TSL bundle should include previewSvg");
+    assert.ok(bundle.previewSvg.includes("<svg"), "previewSvg should contain SVG markup");
   });
 
   runTest("index entries are sorted alphabetically by name", () => {

--- a/scripts/build-registry.ts
+++ b/scripts/build-registry.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { validateShaderManifestFile } from "../packages/schema/src/index.ts";
+import { buildTslPreviewModule } from "../packages/schema/src/tsl-preview-module.ts";
 import type {
   RegistryIndex,
   RegistryIndexEntry,
@@ -99,6 +100,11 @@ export async function buildRegistry({ shadersRoot, outputDir }: BuildRegistryOpt
       ...(manifest.provenance.notes !== undefined ? { notes: manifest.provenance.notes } : {}),
     };
 
+    const previewSvg =
+      manifest.preview.format === "svg"
+        ? readFileSync(join(shaderDir, manifest.preview.path), "utf8")
+        : undefined;
+
     // Index entry
     const indexEntry: RegistryIndexEntry = {
       name: manifest.name,
@@ -133,6 +139,7 @@ export async function buildRegistry({ shadersRoot, outputDir }: BuildRegistryOpt
       outputs: manifest.outputs,
       recipes,
       provenance,
+      ...(previewSvg !== undefined ? { previewSvg } : {}),
     };
 
     if (manifest.language === "glsl") {
@@ -150,6 +157,7 @@ export async function buildRegistry({ shadersRoot, outputDir }: BuildRegistryOpt
         ...sharedBundleFields,
         language: "tsl" as const,
         tslSource,
+        previewModule: buildTslPreviewModule(tslSource),
       };
     }
 


### PR DESCRIPTION
## Summary\n- add a shared TSL preview-module contract and emit prebuilt TSL preview modules in registry bundles\n- render live TSL previews on shader detail pages with the shared WebGPU host instead of the static placeholder\n- reuse the same TSL preview host in the playground so TSL sessions can render live previews there too\n- update playground and MCP capability flags so TSL sessions are treated as preview-capable when a browser is connected\n\n## Validation\n- node --experimental-strip-types packages/cli/src/registry-types.test.ts\n- node --experimental-strip-types packages/cli/src/commands/add.test.ts\n- node --experimental-strip-types scripts/build-registry.test.ts\n- node --experimental-strip-types apps/web/src/lib/server/shaders.test.ts\n- node --experimental-strip-types packages/mcp/src/playground-handlers.test.ts\n- bun run test:web\n- bun run test:mcp\n- bun x tsc -p tsconfig.json --noEmit\n- bun run build:web