### PR TITLE
fix(playground): wait for browser error reports

### DIFF
--- a/apps/web/src/lib/server/playground-db.test.node.ts
+++ b/apps/web/src/lib/server/playground-db.test.node.ts
@@ -8,10 +8,13 @@ process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'playground-test-'))
 const {
   createSession,
   getSession,
+  waitForBrowserSyncResult,
+  waitForErrorReport,
   updateShader,
   setScreenshot,
   setErrors,
   setStructuredErrors,
+  recordErrorReport,
   setUniformValues,
   updateMetadata,
 } = await import('./playground-db.ts')
@@ -170,6 +173,101 @@ runTest('setStructuredErrors stores structured errors', () => {
   setStructuredErrors(id, [...errors])
   const session = getSession(id)!
   assert.deepEqual(session.structuredErrors, errors)
+})
+
+runTest('waitForErrorReport resolves when browser posts errors', async () => {
+  const { id } = createSession()
+  const wait = waitForErrorReport(id, 1_000)
+
+  setTimeout(() => {
+    recordErrorReport(id, {
+      errors: ['shader failed'],
+      structuredErrors: [],
+    })
+  }, 20)
+
+  const report = await wait
+  assert.deepEqual(report, {
+    errors: ['shader failed'],
+    structuredErrors: [],
+  })
+})
+
+runTest('waitForBrowserSyncResult resolves early on compilation errors', async () => {
+  const { id } = createSession()
+  const startedAt = Date.now()
+  const wait = waitForBrowserSyncResult(id, 1_000)
+
+  setTimeout(() => {
+    recordErrorReport(id, {
+      errors: ['compile failed'],
+      structuredErrors: [],
+    })
+  }, 20)
+
+  const result = await wait
+  assert.equal(Date.now() - startedAt < 500, true)
+  assert.equal(result.screenshotBase64, null)
+  assert.deepEqual(result.errorReport, {
+    errors: ['compile failed'],
+    structuredErrors: [],
+  })
+})
+
+runTest('waitForBrowserSyncResult waits for screenshot after a successful empty error report', async () => {
+  const { id } = createSession()
+  const startedAt = Date.now()
+  const wait = waitForBrowserSyncResult(id, 1_000)
+
+  setTimeout(() => {
+    recordErrorReport(id, {
+      errors: [],
+      structuredErrors: [],
+    })
+  }, 20)
+
+  setTimeout(() => {
+    setScreenshot(id, 'data:image/png;base64,ok')
+  }, 60)
+
+  const result = await wait
+  const elapsedMs = Date.now() - startedAt
+
+  assert.equal(elapsedMs >= 40, true)
+  assert.equal(elapsedMs < 500, true)
+  assert.equal(result.screenshotBase64, 'data:image/png;base64,ok')
+  assert.deepEqual(result.errorReport, {
+    errors: [],
+    structuredErrors: [],
+  })
+})
+
+runTest('waitForBrowserSyncResult waits for the error-clear report after screenshot success', async () => {
+  const { id } = createSession()
+  const startedAt = Date.now()
+  const wait = waitForBrowserSyncResult(id, 1_000)
+
+  setTimeout(() => {
+    setScreenshot(id, 'data:image/png;base64,ok')
+  }, 20)
+
+  setTimeout(() => {
+    recordErrorReport(id, {
+      errors: [],
+      structuredErrors: [],
+    })
+  }, 60)
+
+  const result = await wait
+  const elapsedMs = Date.now() - startedAt
+
+  assert.equal(elapsedMs >= 40, true)
+  assert.equal(elapsedMs < 500, true)
+  assert.equal(result.screenshotBase64, 'data:image/png;base64,ok')
+  assert.deepEqual(result.errorReport, {
+    errors: [],
+    structuredErrors: [],
+  })
 })
 
 runTest('setUniformValues stores values', () => {

--- a/apps/web/src/lib/server/playground-db.test.node.ts
+++ b/apps/web/src/lib/server/playground-db.test.node.ts
@@ -270,6 +270,35 @@ runTest('waitForBrowserSyncResult waits for the error-clear report after screens
   })
 })
 
+runTest('waitForBrowserSyncResult returns nulls when the browser never responds', async () => {
+  const { id } = createSession()
+  const result = await waitForBrowserSyncResult(id, 25)
+
+  assert.deepEqual(result, {
+    screenshotBase64: null,
+    errorReport: null,
+  })
+})
+
+runTest('waitForBrowserSyncResult treats structured errors as compilation failures', async () => {
+  const { id } = createSession({ language: 'tsl', tslSource: 'export function createMaterial() {}' })
+  const wait = waitForBrowserSyncResult(id, 1_000)
+
+  setTimeout(() => {
+    recordErrorReport(id, {
+      errors: [],
+      structuredErrors: [{ kind: 'tsl-runtime', message: 'material build failed' }],
+    })
+  }, 20)
+
+  const result = await wait
+  assert.equal(result.screenshotBase64, null)
+  assert.deepEqual(result.errorReport, {
+    errors: [],
+    structuredErrors: [{ kind: 'tsl-runtime', message: 'material build failed' }],
+  })
+})
+
 runTest('setUniformValues stores values', () => {
   const { id } = createSession()
   const values = { uTime: 1.5, uColor: [1, 0, 0] }

--- a/apps/web/src/lib/server/playground-db.ts
+++ b/apps/web/src/lib/server/playground-db.ts
@@ -135,6 +135,12 @@ const sseConnections = new Map<string, Set<WritableStreamDefaultWriter<Uint8Arra
 // Screenshot wait queue: when an update is posted, the API waits for the
 // browser to send a screenshot back. This map stores resolve callbacks.
 const screenshotWaiters = new Map<string, Array<(base64: string | null) => void>>()
+const errorReportWaiters = new Map<string, Array<(report: ErrorReportPayload | null) => void>>()
+
+export type ErrorReportPayload = {
+  errors: string[]
+  structuredErrors: PlaygroundError[]
+}
 
 export function addSSEConnection(sessionId: string, writer: WritableStreamDefaultWriter<Uint8Array>) {
   let set = sseConnections.get(sessionId)
@@ -201,6 +207,85 @@ export function resolveScreenshotWaiters(sessionId: string, base64: string) {
   for (const resolve of list) {
     resolve(base64)
   }
+}
+
+export function waitForErrorReport(sessionId: string, timeoutMs: number): Promise<ErrorReportPayload | null> {
+  return new Promise((resolve) => {
+    const list = errorReportWaiters.get(sessionId) ?? []
+    list.push(resolve)
+    errorReportWaiters.set(sessionId, list)
+    setTimeout(() => {
+      const current = errorReportWaiters.get(sessionId)
+      if (current) {
+        const idx = current.indexOf(resolve)
+        if (idx !== -1) {
+          current.splice(idx, 1)
+          if (current.length === 0) errorReportWaiters.delete(sessionId)
+        }
+      }
+      resolve(null)
+    }, timeoutMs)
+  })
+}
+
+export function resolveErrorReportWaiters(sessionId: string, report: ErrorReportPayload) {
+  const list = errorReportWaiters.get(sessionId)
+  if (!list || list.length === 0) return
+  errorReportWaiters.delete(sessionId)
+  for (const resolve of list) {
+    resolve(report)
+  }
+}
+
+export async function waitForBrowserSyncResult(sessionId: string, timeoutMs: number): Promise<{
+  screenshotBase64: string | null
+  errorReport: ErrorReportPayload | null
+}> {
+  const screenshotPromise = waitForScreenshot(sessionId, timeoutMs).then((base64) => ({
+    type: 'screenshot' as const,
+    base64,
+  }))
+  const errorPromise = waitForErrorReport(sessionId, timeoutMs).then((report) => ({
+    type: 'errorReport' as const,
+    report,
+  }))
+
+  let waitForScreenshotEvent = true
+  let waitForErrorEvent = true
+  let screenshotBase64: string | null = null
+  let errorReport: ErrorReportPayload | null = null
+
+  while (waitForScreenshotEvent || waitForErrorEvent) {
+    const pending: Array<
+      Promise<
+        | { type: 'screenshot'; base64: string | null }
+        | { type: 'errorReport'; report: ErrorReportPayload | null }
+      >
+    > = []
+
+    if (waitForScreenshotEvent) pending.push(screenshotPromise)
+    if (waitForErrorEvent) pending.push(errorPromise)
+
+    const next = await Promise.race(pending)
+
+    if (next.type === 'screenshot') {
+      waitForScreenshotEvent = false
+      screenshotBase64 = next.base64
+    } else {
+      waitForErrorEvent = false
+      errorReport = next.report
+    }
+
+    const hasCompilationErrors = !!errorReport
+      && (errorReport.errors.length > 0 || errorReport.structuredErrors.length > 0)
+    const hasSuccessfulSync = screenshotBase64 !== null && errorReport !== null
+
+    if (hasCompilationErrors || hasSuccessfulSync) {
+      break
+    }
+  }
+
+  return { screenshotBase64, errorReport }
 }
 
 // ---------------------------------------------------------------------------
@@ -352,6 +437,12 @@ export function setStructuredErrors(id: string, errors: PlaygroundError[]): void
   db.prepare(
     `UPDATE playground_sessions SET structured_errors_json = ?, updated_at = datetime('now') WHERE id = ?`,
   ).run(JSON.stringify(errors), id)
+}
+
+export function recordErrorReport(id: string, report: ErrorReportPayload): void {
+  setErrors(id, report.errors)
+  setStructuredErrors(id, report.structuredErrors)
+  resolveErrorReportWaiters(id, report)
 }
 
 export function setUniformValues(id: string, values: Record<string, unknown>): void {

--- a/apps/web/src/lib/webgl-shader-errors.test.ts
+++ b/apps/web/src/lib/webgl-shader-errors.test.ts
@@ -61,4 +61,17 @@ runTest('collectShaderDiagnostics falls back to a generic compile message', () =
   ])
 })
 
+runTest('collectShaderDiagnostics falls back to a generic link message', () => {
+  const diagnostics = collectShaderDiagnostics({
+    gl: mockGl,
+    program: { log: null },
+    vertexShader: { ok: true, log: null },
+    fragmentShader: { ok: true, log: null },
+  })
+
+  assert.deepEqual(diagnostics, [
+    { kind: 'glsl-link', message: 'GLSL program linking failed.' },
+  ])
+})
+
 console.log('webgl-shader-errors tests passed')

--- a/apps/web/src/lib/webgl-shader-errors.ts
+++ b/apps/web/src/lib/webgl-shader-errors.ts
@@ -11,8 +11,8 @@ type ShaderLogContext = {
     getShaderParameter: (shader: unknown, pname: number) => boolean
   }
   program: unknown
-  vertexShader?: unknown | null
-  fragmentShader?: unknown | null
+  vertexShader?: unknown
+  fragmentShader?: unknown
 }
 
 function normalizeLog(log: string | null | undefined): string {

--- a/apps/web/src/routes/api/playground/$.ts
+++ b/apps/web/src/routes/api/playground/$.ts
@@ -4,7 +4,6 @@ import {
   getSession,
   updateShader,
   setScreenshot,
-  setErrors,
   recordErrorReport,
   hasSSEConnections,
   addSSEConnection,

--- a/apps/web/src/routes/api/playground/$.ts
+++ b/apps/web/src/routes/api/playground/$.ts
@@ -5,11 +5,11 @@ import {
   updateShader,
   setScreenshot,
   setErrors,
-  setStructuredErrors,
+  recordErrorReport,
   hasSSEConnections,
   addSSEConnection,
   removeSSEConnection,
-  waitForScreenshot,
+  waitForBrowserSyncResult,
 } from '../../../lib/server/playground-db'
 import type {
   PlaygroundError,
@@ -64,7 +64,7 @@ function jsonResponse(data: unknown, status = 200): Response {
 // ---------------------------------------------------------------------------
 
 const WEB_URL = process.env.WEB_URL || 'https://shaderbase.com'
-const SCREENSHOT_WAIT_MS = 5000
+const BROWSER_SYNC_WAIT_MS = 5000
 
 async function handlePlayground(request: Request): Promise<Response> {
   const url = new URL(request.url)
@@ -170,11 +170,14 @@ async function handlePlayground(request: Request): Promise<Response> {
 
     const previewAvailable = true
 
-    // Wait for screenshot from the browser when it is connected.
+    // Wait for browser feedback when it is connected. Successful renders
+    // should produce both an empty error report and a screenshot. Failed
+    // renders should produce a non-empty error report.
     const browserConnected = hasSSEConnections(sessionId)
     let screenshotBase64: string | null = null
     if (browserConnected) {
-      screenshotBase64 = await waitForScreenshot(sessionId, SCREENSHOT_WAIT_MS)
+      const browserResult = await waitForBrowserSyncResult(sessionId, BROWSER_SYNC_WAIT_MS)
+      screenshotBase64 = browserResult.screenshotBase64
     }
 
     // Re-fetch session to get latest errors
@@ -210,8 +213,10 @@ async function handlePlayground(request: Request): Promise<Response> {
       errors: string[]
       structuredErrors?: PlaygroundError[]
     }
-    setErrors(sessionId, body.errors ?? [])
-    setStructuredErrors(sessionId, body.structuredErrors ?? [])
+    recordErrorReport(sessionId, {
+      errors: body.errors ?? [],
+      structuredErrors: body.structuredErrors ?? [],
+    })
     return jsonResponse({ status: 'ok' })
   }
 


### PR DESCRIPTION
## Summary
- add browser sync waiters for screenshot uploads and error reports in the playground DB layer
- make `/api/playground/:sessionId/update` resolve on actual browser feedback instead of idling on the screenshot timeout
- cover the new wait behavior with timing-aware node tests for failure and success flows

## Verification
- `bun run test:web`
- `bun run build:web`
- manual local repro with a browser-connected playground session now returns invalid GLSL compile errors in ~96ms instead of waiting ~5s

Closes #71.

Stacked on #72.