### PR TITLE
feat(playground): add MCP-first landing page

### DIFF
--- a/apps/web/src/components/TslPreviewCanvas.tsx
+++ b/apps/web/src/components/TslPreviewCanvas.tsx
@@ -3,7 +3,12 @@ import type {
   TslPreviewModuleResult,
   TslPreviewModuleRuntime,
 } from '../../../../packages/schema/src/tsl-preview-module.ts'
-import { createPlainErrorReport, createTslErrorReport, TslPreviewError } from '../lib/tsl-error-reporting'
+import {
+  createKnownTslErrorReport,
+  createPlainErrorReport,
+  createTslErrorReport,
+  TslPreviewError,
+} from '../lib/tsl-error-reporting'
 import type { PlaygroundErrorReport } from '../lib/playground-types'
 
 type THREE = typeof import('three/webgpu')
@@ -161,13 +166,7 @@ export default function TslPreviewCanvas(props: TslPreviewCanvasProps) {
 
   onMount(async () => {
     if (!('gpu' in navigator)) {
-      setPreviewError(
-        createTslErrorReport(
-          new TslPreviewError('tsl-runtime', 'WebGPU is not available in this browser.'),
-          'tsl-runtime',
-          'WebGPU is not available in this browser.',
-        ),
-      )
+      setPreviewError(createKnownTslErrorReport('tsl-runtime', 'WebGPU is not available in this browser.'))
       setLoading(false)
       return
     }

--- a/apps/web/src/components/playground/PlaygroundLanding.tsx
+++ b/apps/web/src/components/playground/PlaygroundLanding.tsx
@@ -1,0 +1,180 @@
+import CodeBlock from '../CodeBlock'
+import Badge from '../ui/Badge'
+import SurfaceCard from '../ui/SurfaceCard'
+
+type PlaygroundLandingProps = {
+  creatingSession: boolean
+  error?: string
+  onStartManualSession: () => void | Promise<void>
+}
+
+const MCP_CONFIG_SNIPPET = `{
+  "mcpServers": {
+    "shaderbase": {
+      "url": "https://mcp.shaderbase.com/mcp"
+    }
+  }
+}`
+
+const CREATE_PLAYGROUND_SNIPPET = `create_playground({
+  language: "tsl",
+  pipeline: "surface"
+})`
+
+export default function PlaygroundLanding(props: PlaygroundLandingProps) {
+  return (
+    <main class="relative overflow-hidden">
+      <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(5,150,105,0.14),transparent_36%),radial-gradient(circle_at_bottom_right,rgba(15,23,41,0.08),transparent_34%)]" />
+
+      <div class="mx-auto flex min-h-[calc(100dvh-56px)] w-full max-w-6xl items-center px-4 py-10 sm:py-14">
+        <SurfaceCard class="relative w-full overflow-hidden rounded-[2rem] border-white/70 bg-white/85 p-6 shadow-[0_30px_80px_-40px_rgba(15,23,41,0.35)] backdrop-blur-xl sm:p-8 lg:p-10">
+          <div class="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/80 to-transparent" />
+
+          <div class="grid gap-10 lg:grid-cols-[1.15fr_0.9fr] lg:gap-12">
+            <div>
+              <div class="mb-5 flex flex-wrap gap-2">
+                <Badge label="agent-first" variant="accent" />
+                <Badge label="mcp session" />
+                <Badge label="manual fallback" />
+              </div>
+
+              <h1 class="max-w-xl text-4xl font-semibold tracking-tight text-text-primary sm:text-5xl">
+                The playground is built for agents to drive live shader iteration.
+              </h1>
+
+              <p class="mt-4 max-w-2xl text-base leading-7 text-text-secondary">
+                Connect an AI client to ShaderBase&apos;s MCP server, call
+                {' '}
+                <code class="rounded bg-surface-secondary px-1.5 py-0.5 font-mono text-[0.9em] text-text-primary">
+                  create_playground
+                </code>
+                , then keep iterating with live previews, screenshots, and structured error feedback.
+              </p>
+
+              <div class="mt-8 space-y-3">
+                <div class="flex gap-4 rounded-2xl border border-surface-card-border/80 bg-surface-primary/70 px-4 py-4">
+                  <span class="font-mono text-xs font-semibold tracking-[0.18em] text-accent">01</span>
+                  <p class="text-sm leading-6 text-text-secondary">
+                    Point your MCP client at
+                    {' '}
+                    <code class="font-mono text-text-primary">https://mcp.shaderbase.com/mcp</code>
+                    {' '}
+                    so it can access the remote ShaderBase tools.
+                  </p>
+                </div>
+
+                <div class="flex gap-4 rounded-2xl border border-surface-card-border/80 bg-surface-primary/70 px-4 py-4">
+                  <span class="font-mono text-xs font-semibold tracking-[0.18em] text-accent">02</span>
+                  <p class="text-sm leading-6 text-text-secondary">
+                    Start a session with
+                    {' '}
+                    <code class="font-mono text-text-primary">create_playground</code>
+                    {' '}
+                    and open the returned
+                    {' '}
+                    <code class="font-mono text-text-primary">/playground?session=...</code>
+                    {' '}
+                    URL in a browser tab.
+                  </p>
+                </div>
+
+                <div class="flex gap-4 rounded-2xl border border-surface-card-border/80 bg-surface-primary/70 px-4 py-4">
+                  <span class="font-mono text-xs font-semibold tracking-[0.18em] text-accent">03</span>
+                  <p class="text-sm leading-6 text-text-secondary">
+                    Iterate from your agent with
+                    {' '}
+                    <code class="font-mono text-text-primary">update_shader</code>
+                    ,
+                    {' '}
+                    <code class="font-mono text-text-primary">get_preview</code>
+                    , and
+                    {' '}
+                    <code class="font-mono text-text-primary">get_errors</code>
+                    .
+                  </p>
+                </div>
+              </div>
+
+              <div class="mt-8 grid gap-4 sm:grid-cols-2">
+                <div class="rounded-2xl border border-surface-card-border/80 bg-surface-primary/70 p-4">
+                  <p class="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-text-muted">
+                    MCP endpoint
+                  </p>
+                  <a
+                    href="https://mcp.shaderbase.com/mcp"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="mt-2 block break-all font-mono text-sm text-accent transition hover:text-accent/75"
+                  >
+                    https://mcp.shaderbase.com/mcp
+                  </a>
+                </div>
+
+                <div class="rounded-2xl border border-surface-card-border/80 bg-surface-primary/70 p-4">
+                  <p class="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-text-muted">
+                    Playground tools
+                  </p>
+                  <p class="mt-2 text-sm leading-6 text-text-secondary">
+                    <code class="font-mono text-text-primary">create_playground</code>
+                    ,{' '}
+                    <code class="font-mono text-text-primary">update_shader</code>
+                    ,{' '}
+                    <code class="font-mono text-text-primary">get_preview</code>
+                    ,{' '}
+                    <code class="font-mono text-text-primary">get_errors</code>
+                  </p>
+                </div>
+              </div>
+
+              <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+                <a
+                  href="https://mcp.shaderbase.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center justify-center rounded-xl bg-accent px-4 py-3 text-sm font-semibold text-white transition hover:-translate-y-[1px] hover:bg-accent/90 active:translate-y-0 active:scale-[0.98]"
+                >
+                  Open MCP server
+                </a>
+
+                <button
+                  type="button"
+                  onClick={() => void props.onStartManualSession()}
+                  disabled={props.creatingSession}
+                  class="inline-flex items-center justify-center rounded-xl border border-surface-card-border bg-surface-card px-4 py-3 text-sm font-semibold text-text-primary transition hover:-translate-y-[1px] hover:border-accent/30 hover:text-accent disabled:cursor-wait disabled:opacity-70 active:translate-y-0 active:scale-[0.98]"
+                >
+                  {props.creatingSession ? 'Starting manual session...' : 'Start manual session'}
+                </button>
+              </div>
+
+              <p class="mt-3 text-sm text-text-muted">
+                Manual sessions are useful for quick experiments, but they are not the primary MCP workflow.
+              </p>
+
+              {props.error ? (
+                <div class="mt-4 rounded-2xl border border-danger/20 bg-danger-dim/35 px-4 py-3 text-sm text-danger">
+                  {props.error}
+                </div>
+              ) : null}
+            </div>
+
+            <div class="space-y-4">
+              <div class="rounded-[1.5rem] border border-surface-card-border/80 bg-surface-primary/80 p-4">
+                <p class="mb-3 text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-text-muted">
+                  Connect your client
+                </p>
+                <CodeBlock code={MCP_CONFIG_SNIPPET} language="Claude config" />
+              </div>
+
+              <div class="rounded-[1.5rem] border border-surface-card-border/80 bg-surface-primary/80 p-4">
+                <p class="mb-3 text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-text-muted">
+                  Start a playground
+                </p>
+                <CodeBlock code={CREATE_PLAYGROUND_SNIPPET} language="Tool call" />
+              </div>
+            </div>
+          </div>
+        </SurfaceCard>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/src/components/playground/PlaygroundLanding.tsx
+++ b/apps/web/src/components/playground/PlaygroundLanding.tsx
@@ -1,3 +1,4 @@
+import { Show } from 'solid-js'
 import CodeBlock from '../CodeBlock'
 import Badge from '../ui/Badge'
 import SurfaceCard from '../ui/SurfaceCard'
@@ -51,8 +52,8 @@ export default function PlaygroundLanding(props: PlaygroundLandingProps) {
                 , then keep iterating with live previews, screenshots, and structured error feedback.
               </p>
 
-              <div class="mt-8 space-y-3">
-                <div class="flex gap-4 rounded-2xl border border-surface-card-border/80 bg-surface-primary/70 px-4 py-4">
+              <ol class="mt-8 space-y-3">
+                <li class="flex gap-4 rounded-2xl border border-surface-card-border/80 bg-surface-primary/70 px-4 py-4">
                   <span class="font-mono text-xs font-semibold tracking-[0.18em] text-accent">01</span>
                   <p class="text-sm leading-6 text-text-secondary">
                     Point your MCP client at
@@ -61,9 +62,9 @@ export default function PlaygroundLanding(props: PlaygroundLandingProps) {
                     {' '}
                     so it can access the remote ShaderBase tools.
                   </p>
-                </div>
+                </li>
 
-                <div class="flex gap-4 rounded-2xl border border-surface-card-border/80 bg-surface-primary/70 px-4 py-4">
+                <li class="flex gap-4 rounded-2xl border border-surface-card-border/80 bg-surface-primary/70 px-4 py-4">
                   <span class="font-mono text-xs font-semibold tracking-[0.18em] text-accent">02</span>
                   <p class="text-sm leading-6 text-text-secondary">
                     Start a session with
@@ -76,9 +77,9 @@ export default function PlaygroundLanding(props: PlaygroundLandingProps) {
                     {' '}
                     URL in a browser tab.
                   </p>
-                </div>
+                </li>
 
-                <div class="flex gap-4 rounded-2xl border border-surface-card-border/80 bg-surface-primary/70 px-4 py-4">
+                <li class="flex gap-4 rounded-2xl border border-surface-card-border/80 bg-surface-primary/70 px-4 py-4">
                   <span class="font-mono text-xs font-semibold tracking-[0.18em] text-accent">03</span>
                   <p class="text-sm leading-6 text-text-secondary">
                     Iterate from your agent with
@@ -92,8 +93,8 @@ export default function PlaygroundLanding(props: PlaygroundLandingProps) {
                     <code class="font-mono text-text-primary">get_errors</code>
                     .
                   </p>
-                </div>
-              </div>
+                </li>
+              </ol>
 
               <div class="mt-8 grid gap-4 sm:grid-cols-2">
                 <div class="rounded-2xl border border-surface-card-border/80 bg-surface-primary/70 p-4">
@@ -150,11 +151,11 @@ export default function PlaygroundLanding(props: PlaygroundLandingProps) {
                 Manual sessions are useful for quick experiments, but they are not the primary MCP workflow.
               </p>
 
-              {props.error ? (
+              <Show when={props.error}>
                 <div class="mt-4 rounded-2xl border border-danger/20 bg-danger-dim/35 px-4 py-3 text-sm text-danger">
-                  {props.error}
+                  <p role="alert" aria-live="assertive">{props.error}</p>
                 </div>
-              ) : null}
+              </Show>
             </div>
 
             <div class="space-y-4">

--- a/apps/web/src/lib/server/playground-db.ts
+++ b/apps/web/src/lib/server/playground-db.ts
@@ -3,6 +3,7 @@ import { mkdirSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import type {
+  PlaygroundErrorReport,
   PlaygroundSession,
   PlaygroundError,
   UniformDefinition,
@@ -135,12 +136,7 @@ const sseConnections = new Map<string, Set<WritableStreamDefaultWriter<Uint8Arra
 // Screenshot wait queue: when an update is posted, the API waits for the
 // browser to send a screenshot back. This map stores resolve callbacks.
 const screenshotWaiters = new Map<string, Array<(base64: string | null) => void>>()
-const errorReportWaiters = new Map<string, Array<(report: ErrorReportPayload | null) => void>>()
-
-export type ErrorReportPayload = {
-  errors: string[]
-  structuredErrors: PlaygroundError[]
-}
+const errorReportWaiters = new Map<string, Array<(report: PlaygroundErrorReport | null) => void>>()
 
 export function addSSEConnection(sessionId: string, writer: WritableStreamDefaultWriter<Uint8Array>) {
   let set = sseConnections.get(sessionId)
@@ -209,7 +205,7 @@ export function resolveScreenshotWaiters(sessionId: string, base64: string) {
   }
 }
 
-export function waitForErrorReport(sessionId: string, timeoutMs: number): Promise<ErrorReportPayload | null> {
+export function waitForErrorReport(sessionId: string, timeoutMs: number): Promise<PlaygroundErrorReport | null> {
   return new Promise((resolve) => {
     const list = errorReportWaiters.get(sessionId) ?? []
     list.push(resolve)
@@ -228,7 +224,7 @@ export function waitForErrorReport(sessionId: string, timeoutMs: number): Promis
   })
 }
 
-export function resolveErrorReportWaiters(sessionId: string, report: ErrorReportPayload) {
+export function resolveErrorReportWaiters(sessionId: string, report: PlaygroundErrorReport) {
   const list = errorReportWaiters.get(sessionId)
   if (!list || list.length === 0) return
   errorReportWaiters.delete(sessionId)
@@ -239,7 +235,7 @@ export function resolveErrorReportWaiters(sessionId: string, report: ErrorReport
 
 export async function waitForBrowserSyncResult(sessionId: string, timeoutMs: number): Promise<{
   screenshotBase64: string | null
-  errorReport: ErrorReportPayload | null
+  errorReport: PlaygroundErrorReport | null
 }> {
   const screenshotPromise = waitForScreenshot(sessionId, timeoutMs).then((base64) => ({
     type: 'screenshot' as const,
@@ -253,13 +249,13 @@ export async function waitForBrowserSyncResult(sessionId: string, timeoutMs: num
   let waitForScreenshotEvent = true
   let waitForErrorEvent = true
   let screenshotBase64: string | null = null
-  let errorReport: ErrorReportPayload | null = null
+  let errorReport: PlaygroundErrorReport | null = null
 
   while (waitForScreenshotEvent || waitForErrorEvent) {
     const pending: Array<
       Promise<
         | { type: 'screenshot'; base64: string | null }
-        | { type: 'errorReport'; report: ErrorReportPayload | null }
+        | { type: 'errorReport'; report: PlaygroundErrorReport | null }
       >
     > = []
 
@@ -439,7 +435,7 @@ export function setStructuredErrors(id: string, errors: PlaygroundError[]): void
   ).run(JSON.stringify(errors), id)
 }
 
-export function recordErrorReport(id: string, report: ErrorReportPayload): void {
+export function recordErrorReport(id: string, report: PlaygroundErrorReport): void {
   setErrors(id, report.errors)
   setStructuredErrors(id, report.structuredErrors)
   resolveErrorReportWaiters(id, report)

--- a/apps/web/src/lib/tsl-error-reporting.test.ts
+++ b/apps/web/src/lib/tsl-error-reporting.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import {
+  createKnownTslErrorReport,
   createPlainErrorReport,
   createTslErrorReport,
   TslPreviewError,
@@ -45,6 +46,34 @@ runTest('createTslErrorReport maps SyntaxError to tsl-parse', () => {
     structuredErrors: [{
       kind: 'tsl-parse',
       message: 'Unexpected token',
+    }],
+  })
+})
+
+runTest('createTslErrorReport falls back to the provided kind for plain Error', () => {
+  const report = createTslErrorReport(
+    new Error('Material compilation failed'),
+    'tsl-runtime',
+    'fallback',
+  )
+
+  assert.deepEqual(report, {
+    errors: ['Material compilation failed'],
+    structuredErrors: [{
+      kind: 'tsl-runtime',
+      message: 'Material compilation failed',
+    }],
+  })
+})
+
+runTest('createKnownTslErrorReport creates a structured TSL error directly', () => {
+  const report = createKnownTslErrorReport('tsl-runtime', 'WebGPU is not available in this browser.')
+
+  assert.deepEqual(report, {
+    errors: ['WebGPU is not available in this browser.'],
+    structuredErrors: [{
+      kind: 'tsl-runtime',
+      message: 'WebGPU is not available in this browser.',
     }],
   })
 })

--- a/apps/web/src/lib/tsl-error-reporting.ts
+++ b/apps/web/src/lib/tsl-error-reporting.ts
@@ -31,6 +31,16 @@ export function createPlainErrorReport(errors: string[]): PlaygroundErrorReport 
   }
 }
 
+export function createKnownTslErrorReport(
+  kind: TslErrorKind,
+  message: string,
+): PlaygroundErrorReport {
+  return {
+    errors: [message],
+    structuredErrors: [{ kind, message }],
+  }
+}
+
 export function createTslErrorReport(
   error: unknown,
   fallbackKind: TslErrorKind,
@@ -43,8 +53,5 @@ export function createTslErrorReport(
       ? 'tsl-parse'
       : fallbackKind
 
-  return {
-    errors: [message],
-    structuredErrors: [{ kind, message }],
-  }
+  return createKnownTslErrorReport(kind, message)
 }

--- a/apps/web/src/routes/playground.tsx
+++ b/apps/web/src/routes/playground.tsx
@@ -2,20 +2,22 @@ import { createFileRoute, useNavigate } from '@tanstack/solid-router'
 import { createServerFn } from '@tanstack/solid-start'
 import { useServerFn } from '@tanstack/solid-start'
 import { createSignal, onMount, Show } from 'solid-js'
+import PlaygroundLanding from '../components/playground/PlaygroundLanding'
 import PlaygroundLayout from '../components/playground/PlaygroundLayout'
+import SurfaceCard from '../components/ui/SurfaceCard'
 import type { PlaygroundSession } from '../lib/playground-types'
 
-const getOrCreateSession = createServerFn({ method: 'GET' })
-  .inputValidator((data: { sessionId?: string }) => data)
+const getSessionById = createServerFn({ method: 'GET' })
+  .inputValidator((data: { sessionId: string }) => data)
   .handler(async ({ data }) => {
-    const { createSession, getSession } = await import('../lib/server/playground-db')
+    const { getSession } = await import('../lib/server/playground-db')
+    return getSession(data.sessionId) ?? null
+  })
 
-    if (data.sessionId) {
-      const session = getSession(data.sessionId)
-      if (session) return session
-    }
-
-    // No session ID or session not found — create a new one
+const createManualSession = createServerFn({ method: 'POST' })
+  .inputValidator((data: Record<string, never>) => data)
+  .handler(async () => {
+    const { createSession } = await import('../lib/server/playground-db')
     const { session } = createSession()
     return session
   })
@@ -29,42 +31,119 @@ export const Route = createFileRoute('/playground')({
 
 function PlaygroundPage() {
   const navigate = useNavigate()
-  const fetchSession = useServerFn(getOrCreateSession)
+  const search = Route.useSearch()
+  const fetchSession = useServerFn(getSessionById)
+  const startManualSession = useServerFn(createManualSession)
   const [session, setSession] = createSignal<PlaygroundSession | null>(null)
-  const [loading, setLoading] = createSignal(true)
-
-  // Read session ID from URL directly — useSearch reactive value isn't
-  // hydrated yet when onMount fires in TanStack Start + SolidJS.
-  const initialSessionId = typeof window !== 'undefined'
-    ? new URLSearchParams(window.location.search).get('session') || undefined
-    : undefined
+  const [loading, setLoading] = createSignal(Boolean(search().session))
+  const [creatingManualSession, setCreatingManualSession] = createSignal(false)
+  const [error, setError] = createSignal('')
 
   onMount(async () => {
+    const initialSessionId = typeof window !== 'undefined'
+      ? new URLSearchParams(window.location.search).get('session') || undefined
+      : undefined
+
+    if (!initialSessionId) {
+      setLoading(false)
+      return
+    }
+
     try {
       const result = await fetchSession({ data: { sessionId: initialSessionId } })
-      const s = result as PlaygroundSession
-      setSession(s)
+      const loadedSession = result as PlaygroundSession | null
 
-      // Update URL with session ID if it changed or was missing
-      if (initialSessionId !== s.id) {
-        navigate({ search: { session: s.id }, replace: true })
+      if (!loadedSession) {
+        setError('Session not found. Create a new session from your agent or start one manually.')
+        return
       }
+
+      setSession(loadedSession)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load playground session.')
     } finally {
       setLoading(false)
     }
   })
 
+  async function handleStartManualSession() {
+    setCreatingManualSession(true)
+    setError('')
+
+    try {
+      const result = await startManualSession({ data: {} })
+      const nextSession = result as PlaygroundSession
+      setSession(nextSession)
+      setLoading(false)
+      navigate({ search: { session: nextSession.id }, replace: true })
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create playground session.')
+    } finally {
+      setCreatingManualSession(false)
+    }
+  }
+
+  const shouldShowLanding = () => !search().session && !session()
+
   return (
-    <Show
-      when={session()}
-      keyed
-      fallback={
-        <div class="flex h-[calc(100vh-56px)] items-center justify-center">
-          <div class="h-6 w-6 animate-spin rounded-full border-2 border-accent border-t-transparent" />
-        </div>
-      }
-    >
-      {(s) => <PlaygroundLayout session={s} />}
-    </Show>
+    <>
+      <Show when={shouldShowLanding()}>
+        <PlaygroundLanding
+          creatingSession={creatingManualSession()}
+          error={error()}
+          onStartManualSession={handleStartManualSession}
+        />
+      </Show>
+
+      <Show when={!shouldShowLanding()}>
+        <Show
+          when={session()}
+          keyed
+          fallback={
+            loading() ? (
+              <div class="flex min-h-[calc(100dvh-56px)] items-center justify-center">
+                <div class="h-6 w-6 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+              </div>
+            ) : (
+              <main class="mx-auto flex min-h-[calc(100dvh-56px)] w-full max-w-3xl items-center px-4 py-10">
+                <SurfaceCard class="w-full rounded-[2rem] p-8">
+                  <p class="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-text-muted">
+                    Playground session
+                  </p>
+                  <h1 class="mt-3 text-3xl font-semibold tracking-tight text-text-primary">
+                    Session unavailable
+                  </h1>
+                  <p class="mt-3 text-sm leading-7 text-text-secondary">
+                    {error() || 'This playground session could not be loaded.'}
+                  </p>
+                  <div class="mt-6 flex flex-col gap-3 sm:flex-row">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setError('')
+                        navigate({ search: {}, replace: true })
+                      }}
+                      class="inline-flex items-center justify-center rounded-xl border border-surface-card-border bg-surface-card px-4 py-3 text-sm font-semibold text-text-primary transition hover:-translate-y-[1px] hover:border-accent/30 hover:text-accent active:translate-y-0 active:scale-[0.98]"
+                    >
+                      Back to MCP instructions
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void handleStartManualSession()}
+                      disabled={creatingManualSession()}
+                      class="inline-flex items-center justify-center rounded-xl bg-accent px-4 py-3 text-sm font-semibold text-white transition hover:-translate-y-[1px] hover:bg-accent/90 disabled:cursor-wait disabled:opacity-70 active:translate-y-0 active:scale-[0.98]"
+                    >
+                      {creatingManualSession() ? 'Starting manual session...' : 'Start manual session'}
+                    </button>
+                  </div>
+                </SurfaceCard>
+              </main>
+            )
+          }
+        >
+          {(loadedSession) => <PlaygroundLayout session={loadedSession} />}
+        </Show>
+      </Show>
+    </>
   )
 }

--- a/apps/web/src/routes/playground.tsx
+++ b/apps/web/src/routes/playground.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, useNavigate } from '@tanstack/solid-router'
 import { createServerFn } from '@tanstack/solid-start'
 import { useServerFn } from '@tanstack/solid-start'
-import { createSignal, onMount, Show } from 'solid-js'
+import { createSignal, Match, onMount, Switch } from 'solid-js'
 import PlaygroundLanding from '../components/playground/PlaygroundLanding'
 import PlaygroundLayout from '../components/playground/PlaygroundLayout'
 import SurfaceCard from '../components/ui/SurfaceCard'
@@ -74,7 +74,6 @@ function PlaygroundPage() {
       const result = await startManualSession({ data: {} })
       const nextSession = result as PlaygroundSession
       setSession(nextSession)
-      setLoading(false)
       navigate({ search: { session: nextSession.id }, replace: true })
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to create playground session.')
@@ -83,67 +82,72 @@ function PlaygroundPage() {
     }
   }
 
-  const shouldShowLanding = () => !search().session && !session()
+  const currentState = () => {
+    if (session()) return 'session'
+    if (loading()) return 'loading'
+    if (!search().session) return 'landing'
+    return 'unavailable'
+  }
 
   return (
-    <>
-      <Show when={shouldShowLanding()}>
+    <Switch>
+      <Match when={currentState() === 'landing'}>
         <PlaygroundLanding
           creatingSession={creatingManualSession()}
           error={error()}
           onStartManualSession={handleStartManualSession}
         />
-      </Show>
+      </Match>
 
-      <Show when={!shouldShowLanding()}>
-        <Show
-          when={session()}
-          keyed
-          fallback={
-            loading() ? (
-              <div class="flex min-h-[calc(100dvh-56px)] items-center justify-center">
-                <div class="h-6 w-6 animate-spin rounded-full border-2 border-accent border-t-transparent" />
-              </div>
-            ) : (
-              <main class="mx-auto flex min-h-[calc(100dvh-56px)] w-full max-w-3xl items-center px-4 py-10">
-                <SurfaceCard class="w-full rounded-[2rem] p-8">
-                  <p class="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-text-muted">
-                    Playground session
-                  </p>
-                  <h1 class="mt-3 text-3xl font-semibold tracking-tight text-text-primary">
-                    Session unavailable
-                  </h1>
-                  <p class="mt-3 text-sm leading-7 text-text-secondary">
-                    {error() || 'This playground session could not be loaded.'}
-                  </p>
-                  <div class="mt-6 flex flex-col gap-3 sm:flex-row">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setError('')
-                        navigate({ search: {}, replace: true })
-                      }}
-                      class="inline-flex items-center justify-center rounded-xl border border-surface-card-border bg-surface-card px-4 py-3 text-sm font-semibold text-text-primary transition hover:-translate-y-[1px] hover:border-accent/30 hover:text-accent active:translate-y-0 active:scale-[0.98]"
-                    >
-                      Back to MCP instructions
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => void handleStartManualSession()}
-                      disabled={creatingManualSession()}
-                      class="inline-flex items-center justify-center rounded-xl bg-accent px-4 py-3 text-sm font-semibold text-white transition hover:-translate-y-[1px] hover:bg-accent/90 disabled:cursor-wait disabled:opacity-70 active:translate-y-0 active:scale-[0.98]"
-                    >
-                      {creatingManualSession() ? 'Starting manual session...' : 'Start manual session'}
-                    </button>
-                  </div>
-                </SurfaceCard>
-              </main>
-            )
-          }
-        >
-          {(loadedSession) => <PlaygroundLayout session={loadedSession} />}
-        </Show>
-      </Show>
-    </>
+      <Match when={currentState() === 'loading'}>
+        <div class="flex min-h-[calc(100dvh-56px)] items-center justify-center">
+          <div class="h-6 w-6 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+        </div>
+      </Match>
+
+      <Match when={currentState() === 'session'}>
+        <PlaygroundLayout session={session() as PlaygroundSession} />
+      </Match>
+
+      <Match when={currentState() === 'unavailable'}>
+        <main class="mx-auto flex min-h-[calc(100dvh-56px)] w-full max-w-3xl items-center px-4 py-10">
+          <SurfaceCard class="w-full rounded-[2rem] p-8">
+            <p class="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-text-muted">
+              Playground session
+            </p>
+            <h1 class="mt-3 text-3xl font-semibold tracking-tight text-text-primary">
+              Session unavailable
+            </h1>
+            <p
+              role="alert"
+              aria-live="assertive"
+              class="mt-3 text-sm leading-7 text-text-secondary"
+            >
+              {error() || 'This playground session could not be loaded.'}
+            </p>
+            <div class="mt-6 flex flex-col gap-3 sm:flex-row">
+              <button
+                type="button"
+                onClick={() => {
+                  setError('')
+                  navigate({ search: {}, replace: true })
+                }}
+                class="inline-flex items-center justify-center rounded-xl border border-surface-card-border bg-surface-card px-4 py-3 text-sm font-semibold text-text-primary transition hover:-translate-y-[1px] hover:border-accent/30 hover:text-accent active:translate-y-0 active:scale-[0.98]"
+              >
+                Back to MCP instructions
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleStartManualSession()}
+                disabled={creatingManualSession()}
+                class="inline-flex items-center justify-center rounded-xl bg-accent px-4 py-3 text-sm font-semibold text-white transition hover:-translate-y-[1px] hover:bg-accent/90 disabled:cursor-wait disabled:opacity-70 active:translate-y-0 active:scale-[0.98]"
+              >
+                {creatingManualSession() ? 'Starting manual session...' : 'Start manual session'}
+              </button>
+            </div>
+          </SurfaceCard>
+        </main>
+      </Match>
+    </Switch>
   )
 }


### PR DESCRIPTION
## Summary
- show an MCP-first onboarding card on /playground when no session query param is present
- keep the existing editor flow for valid sessions and add a recovery state for invalid session links
- include the bundled TSL error-reporting cleanup from PR #75 review feedback

## Testing
- bun run test:web
- bun run build:web

Closes #69